### PR TITLE
fix(open_image_directory): Ctrl+O hotkey and double-click 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version number (e.g., v0.5.0)'
+        description: 'Version number (e.g., v0.5.1)'
         required: true
-        default: 'v0.5.0'
+        default: 'v0.5.1'
 
 permissions:
   contents: write
@@ -439,7 +439,7 @@ jobs:
         EOF
           
           # Extract the specific version section from CHANGELOG.md
-          # Look for the version section (format: ## v0.5.0 - date) and extract until the next version or end
+          # Look for the version section (format: ## v0.5.1 - date) and extract until the next version or end
           echo "Searching for version pattern: ## $VERSION"
           
           # Try to extract changelog content for this version
@@ -662,7 +662,7 @@ jobs:
         #### Windows (PowerShell)
         ```powershell
         # Get checksum of downloaded file
-        Get-FileHash -Algorithm SHA256 GestureSesh-v0.5.0-Windows-x64.exe
+        Get-FileHash -Algorithm SHA256 GestureSesh-v0.5.1-Windows-x64.exe
         
         # Compare with official checksum from checksums.txt
         ```
@@ -670,7 +670,7 @@ jobs:
         #### macOS/Linux
         ```bash
         # Get checksum of downloaded file
-        shasum -a 256 GestureSesh-v0.5.0-macOS.dmg
+        shasum -a 256 GestureSesh-v0.5.1-macOS.dmg
         
         # Compare with official checksum from checksums.txt
         ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed directory opening functionality - Ctrl+O hotkey and double-click now properly open file explorer/finder to the correct image location with file highlighted
 * Improved path resolution using Path.resolve() for consistent cross-platform behavior
-
+* No new features or breaking changes were introduced; this update solely addresses the directory opening bug introduced in v0.5.0.
 
 ## v0.5.0 - 2025-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bug fixes in development
 
 
+## v0.5.1 - 2025-07-31
+
+### Fixed
+
+* Fixed directory opening functionality - Ctrl+O hotkey and double-click now properly open file explorer/finder to the correct image location with file highlighted
+* Improved path resolution using Path.resolve() for consistent cross-platform behavior
+
+
 ## v0.5.0 - 2025-07-05
 
 ### Added

--- a/GestureSesh_macOS.spec
+++ b/GestureSesh_macOS.spec
@@ -53,6 +53,6 @@ app = BUNDLE(
     name='GestureSesh.app',
     icon='ui/resources/icons/brush.icns',
     bundle_identifier='com.gesturesesh.gesturesesh',
-    version='0.4.3',
+    version='0.5.1',
     codesign_identity=os.environ.get('CODESIGN_IDENTITY'),
 )

--- a/src/gesturesesh/__init__.py
+++ b/src/gesturesesh/__init__.py
@@ -4,7 +4,7 @@ GestureSesh - A drawing practice application for artists.
 This package contains the core functionality for the GestureSesh application.
 """
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 __author__ = "adnv3k"
 __email__ = "ali@adnv3k.com"
 

--- a/src/gesturesesh/main.py
+++ b/src/gesturesesh/main.py
@@ -58,7 +58,7 @@ def sound_file(name: str):
     try:
         return resources.as_file(resources.files("sounds") / name)
     except ModuleNotFoundError:
-        print('ModuleNotFoundError in sound_file')
+        print("ModuleNotFoundError in sound_file")
         # Fallback for direct execution - use file path
         # Navigate from current file to project root and find sounds directory
         current_dir = Path(__file__).parent
@@ -1457,6 +1457,9 @@ class SessionDisplay(QWidget, Ui_session_display):
         self.toggle_grayscale_mode_shortcut.activated.connect(
             self.toggle_grayscale_mode
         )
+        # Open image directory
+        self.open_directory_key = QShortcut(QtGui.QKeySequence("Ctrl+O"), self)
+        self.open_directory_key.activated.connect(self.open_image_directory)
 
     # --- dynamic centring helpers ------------------------------------------
     # --- SessionDisplay ---------------------------------------------------
@@ -2263,16 +2266,18 @@ class SessionDisplay(QWidget, Ui_session_display):
         path = self.playlist[self.playlist_position]
         if path.startswith(":/"):
             return
+        resolved_path = str(Path(path).resolve())
         system = platform.system()
         if system == "Windows":
             QtCore.QProcess.startDetached(
-                "explorer.exe", [f"/select,{Path(path).resolve()}"]
+                "explorer.exe", [f"/select,", resolved_path]
             )
         elif system == "Darwin":  # macOS
-            QtCore.QProcess.startDetached("open", ["-R", path])
+            QtCore.QProcess.startDetached("open", ["-R", resolved_path])
         else:  # Linux and other systems
             # Use xdg-open for Linux
-            QtCore.QProcess.startDetached("xdg-open", ["-R", path])
+            parent_dir = resolved_path.parent
+            QtCore.QProcess.startDetached("xdg-open", [parent_dir])
         if event:
             event.accept()
 

--- a/src/gesturesesh/main.py
+++ b/src/gesturesesh/main.py
@@ -53,6 +53,7 @@ from gesturesesh.utils import (
     resources_config,
 )  # This is a generated file from resources.qrc DO NOT REMOVE
 
+
 def sound_file(name: str):
     """Return a context manager yielding the path to an embedded sound file."""
     try:
@@ -111,7 +112,7 @@ class FileDialog(QFileDialog):
         )
 
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 
 class MainApp(QMainWindow, Ui_MainWindow):
@@ -2269,9 +2270,7 @@ class SessionDisplay(QWidget, Ui_session_display):
         resolved_path = str(Path(path).resolve())
         system = platform.system()
         if system == "Windows":
-            QtCore.QProcess.startDetached(
-                "explorer.exe", [f"/select,", resolved_path]
-            )
+            QtCore.QProcess.startDetached("explorer.exe", [f"/select,", resolved_path])
         elif system == "Darwin":  # macOS
             QtCore.QProcess.startDetached("open", ["-R", resolved_path])
         else:  # Linux and other systems

--- a/src/gesturesesh/main.py
+++ b/src/gesturesesh/main.py
@@ -2275,7 +2275,7 @@ class SessionDisplay(QWidget, Ui_session_display):
             QtCore.QProcess.startDetached("open", ["-R", resolved_path])
         else:  # Linux and other systems
             # Use xdg-open for Linux
-            parent_dir = resolved_path.parent
+            parent_dir = Path(resolved_path).parent
             QtCore.QProcess.startDetached("xdg-open", [parent_dir])
         if event:
             event.accept()

--- a/src/gesturesesh/main.py
+++ b/src/gesturesesh/main.py
@@ -2276,7 +2276,7 @@ class SessionDisplay(QWidget, Ui_session_display):
         else:  # Linux and other systems
             # Use xdg-open for Linux
             parent_dir = Path(resolved_path).parent
-            QtCore.QProcess.startDetached("xdg-open", [parent_dir])
+            QtCore.QProcess.startDetached("xdg-open", [str(parent_dir)])
         if event:
             event.accept()
 


### PR DESCRIPTION
### Summary
Fix directory-opening in SessionDisplay:  
• Correct path resolution so double-click and Ctrl+O reliably open OS’s file manager  
• Add missing Ctrl+O shortcut  

### Version bump
Bump to v0.5.1, update CHANGELOG and CI/CD defaults.
