### PR TITLE
Fix session filter shortcuts when toolbar buttons are visible

### DIFF
--- a/src/gesturesesh/ui/session_display.py
+++ b/src/gesturesesh/ui/session_display.py
@@ -314,21 +314,18 @@ class Ui_session_display(object):
                 "Grayscale<br><span style='font-weight:650;'>G</span>",
             )
         )
-        self.grayscale_button.setShortcut(_translate("session_display", "G"))
         self.flip_horizontal_button.setToolTip(
             _translate(
                 "session_display",
                 "Flip horizontal<br><span style='font-weight:650;'>H</span>",
             )
         )
-        self.flip_horizontal_button.setShortcut(_translate("session_display", "H"))
         self.flip_vertical_button.setToolTip(
             _translate(
                 "session_display",
                 "Flip vertical<br><span style='font-weight:650;'>V</span>",
             )
         )
-        self.flip_vertical_button.setShortcut(_translate("session_display", "V"))
         self.previous_image.setToolTip(
             _translate(
                 "session_display",

--- a/tests/test_gesturesesh.py
+++ b/tests/test_gesturesesh.py
@@ -29,6 +29,59 @@ from gesturesesh.ui.main_window import Ui_MainWindow
 from gesturesesh.ui.session_display import Ui_session_display
 
 
+class TestSessionDisplayShortcuts(unittest.TestCase):
+    def test_filter_buttons_do_not_own_window_shortcuts(self):
+        widget = QtWidgets.QWidget()
+        ui = Ui_session_display()
+        ui.setupUi(widget)
+
+        self.assertTrue(ui.grayscale_button.shortcut().isEmpty())
+        self.assertTrue(ui.flip_horizontal_button.shortcut().isEmpty())
+        self.assertTrue(ui.flip_vertical_button.shortcut().isEmpty())
+
+    def test_filter_shortcuts_are_registered_on_session_window(self):
+        class DummySession(QtWidgets.QWidget):
+            pass
+
+        dummy = DummySession()
+        callback_names = [
+            "toggle_resize",
+            "toggle_always_on_top",
+            "toggle_mute",
+            "add_30_seconds",
+            "add_60_seconds",
+            "restart_timer",
+            "skip_image",
+            "toggle_frameless",
+            "toggle_fullscreen_frameless",
+            "increase_brightness",
+            "decrease_brightness",
+            "increase_contrast",
+            "decrease_contrast",
+            "toggle_threshold",
+            "toggle_edge",
+            "reset_image_mods",
+            "toggle_grayscale_mode",
+            "grayscale",
+            "flip_horizontal",
+            "flip_vertical",
+            "open_image_directory",
+            "toggle_zoom_enabled",
+            "reset_zoom_to_default",
+            "quick_inspect",
+            "toggle_zoom_reset_mode",
+            "open_shortcut_map",
+        ]
+        for name in callback_names:
+            setattr(dummy, name, lambda: None)
+
+        SessionDisplay.init_shortcuts(dummy)
+
+        self.assertEqual(dummy.grayscale_shortcut.key().toString(), "G")
+        self.assertEqual(dummy.flip_horizontal_shortcut.key().toString(), "H")
+        self.assertEqual(dummy.flip_vertical_shortcut.key().toString(), "V")
+
+
 def mock_main_app_setup_ui(self, main_window):
     self.selected_items = MagicMock(spec=QtWidgets.QTextEdit)
     self.preset_loader_box = MagicMock(spec=QtWidgets.QComboBox)

--- a/ui/display_session.ui
+++ b/ui/display_session.ui
@@ -200,9 +200,6 @@ G</string>
            <height>24</height>
           </size>
          </property>
-         <property name="shortcut">
-          <string>G</string>
-         </property>
          <property name="checkable">
           <bool>true</bool>
          </property>
@@ -230,7 +227,7 @@ G</string>
          </property>
          <property name="toolTip">
           <string>Flip horizontal
-F</string>
+H</string>
          </property>
          <property name="styleSheet">
           <string notr="true">background: rgb(119, 153, 146);</string>
@@ -247,9 +244,6 @@ F</string>
            <width>24</width>
            <height>24</height>
           </size>
-         </property>
-         <property name="shortcut">
-          <string>H</string>
          </property>
          <property name="checkable">
           <bool>true</bool>
@@ -277,8 +271,8 @@ F</string>
           <enum>Qt::NoFocus</enum>
          </property>
          <property name="toolTip">
-          <string>Flip horizontal
-F</string>
+          <string>Flip vertical
+V</string>
          </property>
          <property name="styleSheet">
           <string notr="true">background: rgb(119, 153, 146);</string>
@@ -295,9 +289,6 @@ F</string>
            <width>24</width>
            <height>24</height>
           </size>
-         </property>
-         <property name="shortcut">
-          <string>V</string>
          </property>
          <property name="checkable">
           <bool>true</bool>


### PR DESCRIPTION
## Summary
- Remove duplicate button-owned shortcuts for grayscale, horizontal flip, and vertical flip.
- Keep `G`, `H`, and `V` registered at the session window level so they work regardless of toolbar button visibility.
- Add regression coverage for shortcut ownership and registration.

