### PR TITLE
Add Selection Order Viewer for configurable image ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,13 +32,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Image modification state now persists across sessions (`hflip`, `vflip`, brightness, contrast, threshold, edge mode), so your display adjustments are restored on next launch.
 - Recent-session restore now reloads both selected folders and directly-added files (with de-duplication and break-placeholder filtering).
 - Broader image-format support in selection and session playback: `.avif`, `.gif`, `.jxl`, and `.webp` were added to supported types.
-- New **Manage Loaded Images** dialog for curation workflows:
+- New **Selection Order Viewer** (`Ctrl+Shift+I`) for curation workflows:
+  - thumbnail list with selection order, filename, path, and status markers
+  - detail preview panel with image metadata
+  - selection stats for scheduled/extra/short images, folders, missing files, duplicates, and file types
   - filter by name/path
+  - add files/folders
   - remove selected/missing entries
-  - move selected items up/down
+  - move selected items up/down/top/bottom
+  - shuffle or sort by filename/path
   - duplicate highlighting toggle
   - open containing folder
-- New in-session Manage warning banner: when opened during an active session, Manage now explains that edits apply to the next session.
+- New in-session order viewer access (`Ctrl+Shift+I`) for inspecting the live session order and editing upcoming images while already-shown items and break markers remain locked.
+- Randomized selections can now be previewed in their effective order; applying that preview locks the order and disables additional randomization for the next session start.
 - New zoom and inspection controls in the session window:
   - zoom enable toggle (`Z`)
   - reset zoom (`0`)
@@ -63,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored the session runtime further so image decode/render logic now lives in a dedicated loader mixin instead of `session_window.py`, and shortcut registration is centralized in `SessionShortcutsMixin`.
 - Reworked status messaging into a queued system with dedupe behavior and richer fade/blink rendering.
 - Recent-session restore now merges folder scans with direct-file entries and de-duplicates resulting selections.
+- Session startup now builds randomized and break-inserted playlists from copies, so the saved selection order is no longer mutated just by starting a session.
 - Session controls were simplified for a cleaner display:
   - removed queue-preview feature and its toggle/shortcut
   - removed session top-bar total-count wording/label
@@ -77,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - better alignment between scheduled entries and current playlist position
   - safer end-of-session anchoring to scheduled span
 - Improved decode robustness for high bit-depth and mixed-source images via normalization before render.
+- Improved selection viewer responsiveness by loading only visible thumbnails plus a small scroll buffer, using scaled image reads instead of decoding every selected image during dialog startup.
 - Preserved import and patch compatibility during refactor (`MainApp`, `SessionDisplay`, `BREAK_IMAGE_PATH`, `ScheduleEntry`, and `save_config` patch points).
 
 ### Technical
@@ -90,6 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - break/review-mode schedule synchronization
   - preset-linked selection persistence and backward compatibility
   - duplicate detection/reporting paths
+  - selection order helper behavior, shortcut registration, and order-dialog mutation rules
 
 
 ## v0.5.2 - 2026-04-23

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ GestureSesh supercharges gesture practice using your own reference folders. The 
 
 - **Cross-platform** PyQt5 interface with a unified dark theme.
 - **Recursive folder scanning** with duplicate cleanup.
-- **Manage Loaded Images** dialog for quick filtering, reordering, duplicate review, and cleanup.
+- **Selection Order Viewer** (`Ctrl + Shift + I`) with thumbnails, selection stats, filtering, duplicate/missing review, add/remove tools, sorting, shuffling, and manual order controls.
 - **Custom schedule builder**: timed entries, breaks (0-image rows), randomization, and preset saving.
 - **Auto-reload** of your last session (images, schedule, randomization) plus persisted session display preferences and image modifications.
-- **In-session safety notice**: opening Manage during an active session shows a warning that changes apply to the next session, not the current one.
+- **In-session order management**: open the same viewer from the session window to inspect the current order and manage upcoming images without changing already-shown items.
 - **Window options** (grayscale, flip, always-on-top, frameless) via hotkeys.  
   <div align="center">
     <img src="docs/Screenshots/Grayscale%20Comparison.png" alt="Grayscale example" width="80%" />
@@ -80,8 +80,9 @@ GestureSesh supercharges gesture practice using your own reference folders. The 
 - Presets now support wrapped session metadata and preserve per-preset resize behavior when loading sessions.
 - Improved recent-session restore to reload both folders and direct-file selections with duplicate-safe filtering.
 - Expanded image support to include **AVIF, GIF, JXL, and WEBP** across selection and session playback.
-- Added **Manage Loaded Images** workflow tools (filtering, duplicate inspection, reorder, remove missing, quick folder open).
-- Added **in-session Manage warning** so edits are clearly marked as applying to future sessions.
+- Added **Selection Order Viewer** (`Ctrl + Shift + I`) with thumbnail previews, stats, filtering, duplicate/missing inspection, add/remove tools, sorting, shuffling, and manual order controls.
+- Added **in-session order management** so the current session order can be inspected and upcoming images can be adjusted while already-shown items and break markers stay protected.
+- Randomized selections can now be previewed in their effective order before starting a session; applying the preview locks that order and turns randomization off.
 - Added **Shortcut Map dialog** (`F1` / `Ctrl + /`) for in-session key and input reference.
 - Added richer **zoom/pan controls** (wheel/pinch/stylus paths, quick inspect, zoom reset, and auto-reset toggle).
 - Improved decode/render robustness with fallback decode paths and still/animation caching.
@@ -100,6 +101,7 @@ GestureSesh supercharges gesture practice using your own reference folders. The 
 | Clear Selection        | Ctrl + Shift + C                 |
 | Toggle Randomization   | Ctrl + R                         |
 | Remove Duplicates      | Ctrl + 1 *(one per filename)*    |
+| Manage Selection Order | Ctrl + Shift + I                 |
 | Add Entry              | Shift + Enter                    |
 | Save Preset            | Ctrl + S                         |
 | Delete Preset          | Ctrl + Shift + D                 |
@@ -134,6 +136,7 @@ GestureSesh supercharges gesture practice using your own reference folders. The 
 | Toggle Zoom / Pan             | Z                                     |
 | Reset Zoom                    | 0                                     |
 | Quick Inspect                 | I                                     |
+| Manage Session Order          | Ctrl + Shift + I                      |
 | Toggle Auto Zoom Reset        | Ctrl + Shift + Z                      |
 | Open Shortcut Map             | F1 or Ctrl + /                        |
 | Increase Brightness           | Ctrl + PgUp                           |

--- a/src/gesturesesh/app/presets.py
+++ b/src/gesturesesh/app/presets.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-import random
-
 from PyQt5 import QtCore
 from PyQt5.QtWidgets import QTableWidgetItem
 
+from gesturesesh.app.selection_order import effective_selection_order
 from gesturesesh.session.constants import BREAK_IMAGE_PATH
 from gesturesesh.utils.config import save_config
 from gesturesesh.utils.time import format_seconds
@@ -148,12 +147,9 @@ class MainAppPresetsMixin:
             self.entry_table.removeRow(0)
 
     def randomize_items(self):
-        copy = self.selection["files"].copy()
-        randomized_items = []
-        while len(copy) > 0:
-            random_index = random.randint(0, len(copy) - 1)
-            randomized_items.append(copy.pop(random_index))
-        self.selection["files"] = randomized_items
+        self.selection["files"] = effective_selection_order(
+            self.selection["files"], randomize=True
+        )
         self.display_status()
 
     def update_total(self):

--- a/src/gesturesesh/app/selection.py
+++ b/src/gesturesesh/app/selection.py
@@ -7,6 +7,11 @@ import os
 from PyQt5.QtWidgets import QFileDialog
 
 from gesturesesh.app.file_dialog import FileDialog
+from gesturesesh.app.selection_order import (
+    duplicate_indices,
+    effective_selection_order,
+)
+from gesturesesh.ui.dialogs import run_selection_order_dialog
 
 
 class MainAppSelectionMixin:
@@ -162,4 +167,43 @@ class MainAppSelectionMixin:
         else:
             self.show_temporary_status("No duplicates found")
 
+        self.display_status()
+
+    def open_selection_order_viewer(self):
+        """Open the selection viewer/order editor from the main window."""
+        if not self.selection["files"]:
+            self.show_error_status("No images selected to manage.", 2500)
+            return
+
+        try:
+            self.grab_schedule()
+        except Exception:
+            self.session_schedule = []
+
+        random_preview = bool(self.randomize_selection.isChecked())
+        files = effective_selection_order(
+            self.selection["files"], randomize=random_preview
+        )
+        result = run_selection_order_dialog(
+            parent=self,
+            files=files,
+            folders=self.selection["folders"],
+            schedule=self.session_schedule,
+            valid_file_types=self.valid_file_types,
+            duplicate_indices_fn=duplicate_indices,
+            title="Selection Order",
+            random_preview=random_preview,
+        )
+        if result is None:
+            return
+
+        self.selection["files"] = result["files"]
+        self.selection["folders"] = result["folders"]
+        if result.get("random_preview"):
+            self.randomize_selection.setChecked(False)
+            self.show_temporary_status(
+                "Selection order applied. Randomization turned off.", 3500
+            )
+        else:
+            self.show_temporary_status("Selection order updated.", 2500)
         self.display_status()

--- a/src/gesturesesh/app/selection_order.py
+++ b/src/gesturesesh/app/selection_order.py
@@ -1,0 +1,124 @@
+"""Selection ordering helpers shared by the main and session windows."""
+
+from __future__ import annotations
+
+import os
+import random
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+from gesturesesh.session.constants import BREAK_IMAGE_PATH
+
+
+@dataclass(frozen=True)
+class SelectionStats:
+    total_files: int
+    folder_count: int
+    scheduled_images: int
+    extra_images: int
+    shortage_images: int
+    missing_files: int
+    duplicate_files: int
+    extension_counts: dict[str, int]
+
+
+def scheduled_image_count(schedule) -> int:
+    """Return the number of real images required by a schedule."""
+    return sum(max(0, int(getattr(entry, "images", 0))) for entry in schedule or [])
+
+
+def effective_selection_order(files, randomize=False, rng=None) -> list[str]:
+    """Return the order a session should use without mutating the source list."""
+    ordered = [path for path in files if path != BREAK_IMAGE_PATH]
+    if randomize:
+        shuffled = list(ordered)
+        (rng or random).shuffle(shuffled)
+        return shuffled
+    return ordered
+
+
+def playlist_with_breaks(files, schedule, break_path=BREAK_IMAGE_PATH) -> list[str]:
+    """Return a session playlist with break placeholders inserted."""
+    playlist = list(files)
+    current_index = 0
+    for entry in schedule or []:
+        image_count = int(getattr(entry, "images", 0))
+        if image_count == 0:
+            playlist.insert(current_index, break_path)
+            current_index += 1
+        else:
+            current_index += image_count
+    return playlist
+
+
+def real_image_paths(files) -> list[str]:
+    """Return only user-selected images, excluding internal break markers."""
+    return [path for path in files if path != BREAK_IMAGE_PATH]
+
+
+def duplicate_indices(files) -> set[int]:
+    """Return indices after the first occurrence of the same filesystem target."""
+    seen = set()
+    duplicates = set()
+    for index, file_path in enumerate(files):
+        if file_path == BREAK_IMAGE_PATH:
+            continue
+        try:
+            stat = os.stat(file_path)
+            key = (stat.st_dev, stat.st_ino)
+        except (OSError, PermissionError):
+            key = os.path.normcase(os.path.abspath(file_path))
+        if key in seen:
+            duplicates.add(index)
+        else:
+            seen.add(key)
+    return duplicates
+
+
+def remove_duplicate_paths(files) -> list[str]:
+    """Keep the first occurrence of each duplicate target."""
+    duplicates = duplicate_indices(files)
+    return [path for index, path in enumerate(files) if index not in duplicates]
+
+
+def selection_stats(files, folders=None, schedule=None) -> SelectionStats:
+    """Compute summary information used by the selection viewer."""
+    real_files = real_image_paths(files)
+    scheduled = scheduled_image_count(schedule)
+    missing = sum(1 for path in real_files if not Path(path).is_file())
+    duplicate_count = len(duplicate_indices(real_files))
+    extensions = Counter(Path(path).suffix.lower() or "(none)" for path in real_files)
+    extra = max(0, len(real_files) - scheduled) if scheduled else len(real_files)
+    shortage = max(0, scheduled - len(real_files))
+
+    return SelectionStats(
+        total_files=len(real_files),
+        folder_count=len(folders or []),
+        scheduled_images=scheduled,
+        extra_images=extra,
+        shortage_images=shortage,
+        missing_files=missing,
+        duplicate_files=duplicate_count,
+        extension_counts=dict(sorted(extensions.items())),
+    )
+
+
+def remaining_required_images(schedule, playlist, playlist_position) -> int:
+    """Return remaining real image slots from the current playlist position."""
+    if not schedule:
+        return len(real_image_paths(playlist[playlist_position:]))
+
+    required = 0
+    cursor = 0
+    for entry in schedule:
+        count = int(getattr(entry, "images", 0))
+        slots = count if count > 0 else 1
+        for slot_offset in range(slots):
+            playlist_index = cursor + slot_offset
+            if playlist_index < playlist_position:
+                continue
+            if count > 0:
+                required += 1
+        cursor += slots
+    return required

--- a/src/gesturesesh/app/session.py
+++ b/src/gesturesesh/app/session.py
@@ -8,6 +8,10 @@ from pathlib import Path
 from PyQt5.QtTest import QTest
 
 from gesturesesh.app.models import ScheduleEntry
+from gesturesesh.app.selection_order import (
+    effective_selection_order,
+    playlist_with_breaks,
+)
 from gesturesesh.session.constants import BREAK_IMAGE_PATH
 from gesturesesh.session_window import SessionDisplay
 from gesturesesh.utils.config import save_config
@@ -31,13 +35,14 @@ class MainAppSessionMixin:
             QTest.qWait(4000)
             self.display_status()
             return
-        if self.randomize_selection.isChecked():
-            self.randomize_items()
         self.save_to_recent()
 
         self.save(wait_status=False)
 
-        self.insert_breaks()
+        ordered_files = effective_selection_order(
+            self.selection["files"], randomize=self.randomize_selection.isChecked()
+        )
+        session_playlist = self.insert_breaks(ordered_files)
         # Pass recent session settings (if any) into the SessionDisplay so
         # initial display state (resize, grayscale, zoom, etc.) is preserved.
         session_settings = None
@@ -66,7 +71,7 @@ class MainAppSessionMixin:
 
         self.display = SessionDisplay(
             schedule=self.session_schedule,
-            items=self.selection["files"],
+            items=session_playlist,
             total=self.total_scheduled_images,
             settings=session_settings,
         )
@@ -211,16 +216,17 @@ class MainAppSessionMixin:
             return False
         return True
 
-    def insert_breaks(self):
+    def insert_breaks(self, files=None):
         """Inserts break images as specified by the schedule."""
-        if self.has_break:
-            current_index = 0
-            for entry in self.session_schedule:
-                if entry.images == 0:
-                    self.selection["files"].insert(current_index, BREAK_IMAGE_PATH)
-                    current_index += 1
-                else:
-                    current_index += entry.images
+        source_files = self.selection["files"] if files is None else files
+        playlist = playlist_with_breaks(source_files, self.session_schedule)
+        if files is None:
+            self.selection["files"] = playlist
+        return playlist
+
+    def build_session_playlist(self, files):
+        """Build a session playlist from an explicit file order."""
+        return playlist_with_breaks(files, self.session_schedule)
 
     def remove_breaks(self):
         """Removes all occurrences of break.png from the list of selected files."""
@@ -233,6 +239,7 @@ class MainAppSessionMixin:
     def grab_schedule(self):
         """Builds self.session_schedule with data from the schedule."""
         self.session_schedule = []
+        self.has_break = False
         for row in range(self.entry_table.rowCount()):
             images = int(self.entry_table.item(row, 1).text())
             time = int(self.entry_table.item(row, 2).text())

--- a/src/gesturesesh/main.py
+++ b/src/gesturesesh/main.py
@@ -8,6 +8,7 @@ from PyQt5.QtWidgets import (
     QApplication,
     QGraphicsOpacityEffect,
     QMainWindow,
+    QPushButton,
     QShortcut,
 )
 
@@ -64,6 +65,7 @@ class MainApp(
         self.status_opacity_effect = QGraphicsOpacityEffect()
         self.selected_items.setGraphicsEffect(self.status_opacity_effect)
 
+        self.init_selection_order_controls()
         self.init_buttons()
         self.init_shortcuts()
         self.init_preset()
@@ -119,6 +121,22 @@ class MainApp(
         self.set_number_of_images.setFont(font)
         self.set_minutes.setFont(font)
         self.set_seconds.setFont(font)
+        if hasattr(self, "manage_order"):
+            self.manage_order.setFont(font)
+
+    def init_selection_order_controls(self):
+        parent = getattr(self, "centralwidget", self)
+        self.manage_order = QPushButton("Manage Order", parent)
+        self.manage_order.setFocusPolicy(QtCore.Qt.NoFocus)
+        self.manage_order.setStyleSheet("background: rgb(119, 153, 146); color: white;")
+        self.manage_order.setToolTip("View and reorder selected images.\nShortcut: Ctrl+Shift+I")
+        try:
+            self.horizontalLayout_5.addWidget(self.manage_order)
+        except Exception:
+            try:
+                self.verticalLayout_4.addWidget(self.manage_order)
+            except Exception:
+                pass
 
     def init_buttons(self):
         # Buttons for selection
@@ -126,6 +144,7 @@ class MainApp(
         self.clear_items.clicked.connect(self.remove_items)
         self.randomize_selection.clicked.connect(self.display_random_status)
         self.remove_duplicates.clicked.connect(self.remove_dupes)
+        self.manage_order.clicked.connect(self.open_selection_order_viewer)
         # Buttons for preset
         self.add_entry.clicked.connect(self.append_schedule)
         self.save_preset.clicked.connect(self.save)
@@ -155,6 +174,10 @@ class MainApp(
         # Escape to close window
         self.escape_shortcut = QShortcut(QtGui.QKeySequence("Escape"), self)
         self.escape_shortcut.activated.connect(self.close)
+        self.manage_order_shortcut = QShortcut(
+            QtGui.QKeySequence("Ctrl+Shift+I"), self
+        )
+        self.manage_order_shortcut.activated.connect(self.open_selection_order_viewer)
 
     def check_version(self):
         """

--- a/src/gesturesesh/session/shortcuts.py
+++ b/src/gesturesesh/session/shortcuts.py
@@ -190,6 +190,13 @@ class SessionShortcutsMixin:
             "Toggle between default zoom and inspection zoom.",
             "Zoom & Pan",
         )
+        self.selection_order_key = register_shortcut(
+            "Ctrl+Shift+I",
+            self.open_session_order_viewer,
+            "Open selection order",
+            "View and manage the current session image order.",
+            "Navigation",
+        )
         self.zoom_autoreset_key = register_shortcut(
             "Ctrl+Shift+Z",
             self.toggle_zoom_reset_mode,

--- a/src/gesturesesh/session_window.py
+++ b/src/gesturesesh/session_window.py
@@ -15,14 +15,26 @@ from PyQt5 import QtCore, QtWidgets
 from PyQt5.QtTest import QTest
 from PyQt5.QtWidgets import QWidget
 
-from gesturesesh.session.constants import BREAK_IMAGE_PATH, sound_file
+from gesturesesh.session.constants import (
+    BREAK_IMAGE_PATH,
+    SUPPORTED_IMAGE_TYPES,
+    sound_file,
+)
+from gesturesesh.app.selection_order import (
+    real_image_paths,
+    remaining_required_images,
+)
 from gesturesesh.session.image_loader import SessionImageLoaderMixin
 from gesturesesh.session.image_mods import SessionImageModsMixin
 from gesturesesh.session.shortcuts import SessionShortcutsMixin
 from gesturesesh.session.timer import SessionTimerMixin
 from gesturesesh.session.zoom_pan import SessionZoomPanMixin
 from gesturesesh.utils import resources_config  # noqa: F401
-from gesturesesh.ui.dialogs import run_shortcut_map_dialog, ShortcutMapDialog
+from gesturesesh.ui.dialogs import (
+    run_selection_order_dialog,
+    run_shortcut_map_dialog,
+    ShortcutMapDialog,
+)
 from gesturesesh.ui.dot_indicator import DotIndicator
 from gesturesesh.ui.session_display import Ui_session_display
 
@@ -223,8 +235,15 @@ class SessionDisplay(
         self.shortcuts_button.setToolTip("Open shortcut map.\nShortcut: F1")
         self.shortcuts_button.clicked.connect(self.open_shortcut_map)
 
+        self.order_button = QtWidgets.QPushButton("Order", self)
+        self.order_button.setToolTip(
+            "View and manage session order.\nShortcut: Ctrl+Shift+I"
+        )
+        self.order_button.clicked.connect(self.open_session_order_viewer)
+
         for button in (
             self.zoom_toggle_button,
+            self.order_button,
             self.shortcuts_button,
         ):
             button.setFocusPolicy(QtCore.Qt.NoFocus)
@@ -381,6 +400,8 @@ class SessionDisplay(
             btn.setIconSize(icon_size)
         self.zoom_toggle_button.setMinimumWidth(54)
         self.zoom_toggle_button.setFixedHeight(button_size.height())
+        self.order_button.setMinimumWidth(58)
+        self.order_button.setFixedHeight(button_size.height())
         self.shortcuts_button.setFixedSize(QtCore.QSize(36, button_size.height()))
         self._update_control_density()
 
@@ -419,6 +440,8 @@ class SessionDisplay(
 
         self.zoom_toggle_button.setFixedHeight(text_h)
         self.zoom_toggle_button.setMinimumWidth(46 if width <= 520 else 54)
+        self.order_button.setFixedHeight(text_h)
+        self.order_button.setMinimumWidth(52 if width <= 520 else 58)
         self.shortcuts_button.setFixedSize(QtCore.QSize(30 if width <= 520 else 36, text_h))
         self.timer_display.setFixedHeight(text_h)
         self.horizontalLayout_3.setAlignment(self.timer_display, QtCore.Qt.AlignVCenter)
@@ -431,6 +454,7 @@ class SessionDisplay(
         self.flip_horizontal_button.setVisible(not compact)
         self.flip_vertical_button.setVisible(not compact)
         self.shortcuts_button.setVisible(not ultra_compact)
+        self.order_button.setVisible(not micro)
         self.zoom_toggle_button.setVisible(not micro)
 
         self.horizontalLayout.setSpacing(spacing)
@@ -466,6 +490,45 @@ class SessionDisplay(
                 run_shortcut_map_dialog(parent=self, shortcut_rows=self.shortcut_map_rows)
             except Exception:
                 pass
+
+    def _validate_session_order(self, files):
+        required = remaining_required_images(
+            self.schedule, self.playlist, self.playlist_position
+        )
+        available = len(real_image_paths(files[self.playlist_position :]))
+        if available < required:
+            return (
+                "The session still needs "
+                f"{required} image(s) from the current point forward, but this order "
+                f"only has {available}. Add images or undo removals before applying."
+            )
+        return None
+
+    def open_session_order_viewer(self):
+        was_timer_active = self.timer.isActive()
+        if not self.session_finished and was_timer_active:
+            self.timer.stop()
+            self._set_timer_visuals(False)
+
+        result = run_selection_order_dialog(
+            parent=self,
+            files=self.playlist,
+            schedule=self.schedule,
+            valid_file_types=SUPPORTED_IMAGE_TYPES,
+            locked_until=self.playlist_position if not self.session_finished else -1,
+            current_index=self.playlist_position,
+            validate_files=None if self.session_finished else self._validate_session_order,
+            title="Session Order",
+        )
+        if result is not None:
+            self.playlist = result["files"]
+            self.clear_decode_caches()
+            self._sync_entry_to_playlist_position()
+            self.display_image(play_sound=False)
+
+        if not self.session_finished and was_timer_active:
+            self.timer.start(500)
+            self._set_timer_visuals(True)
 
     # --- dynamic centring helpers ------------------------------------------
     # --- SessionDisplay ---------------------------------------------------

--- a/src/gesturesesh/ui/dialogs.py
+++ b/src/gesturesesh/ui/dialogs.py
@@ -3,30 +3,70 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 
+from gesturesesh.app.selection_order import (
+    BREAK_IMAGE_PATH,
+    duplicate_indices,
+    selection_stats,
+)
+
+
+class OrderListWidget(QtWidgets.QListWidget):
+    """List widget that reports drag reorders back to its dialog."""
+
+    def dropEvent(self, event):
+        super().dropEvent(event)
+        dialog = self.window()
+        if hasattr(dialog, "_sync_working_files_from_list"):
+            dialog._sync_working_files_from_list()
+
 
 class ImageManagerDialog(QtWidgets.QDialog):
-    """Dialog that allows users to inspect and curate currently loaded images."""
+    """Dialog that allows users to inspect, order, and curate selected images."""
 
     def __init__(
         self,
         parent,
         files,
-        duplicate_indices_fn,
+        duplicate_indices_fn=None,
         on_no_duplicates=None,
         notice_text=None,
+        valid_file_types=None,
+        folders=None,
+        schedule=None,
+        locked_until=-1,
+        current_index=None,
+        validate_files=None,
+        title="Selection Order",
+        random_preview=False,
     ):
         super().__init__(parent)
-        self.setWindowTitle("Manage Loaded Images")
-        self.resize(940, 560)
+        self.setWindowTitle(title)
+        self.resize(1100, 680)
         self.setModal(True)
 
-        self._duplicate_indices_fn = duplicate_indices_fn
+        self._duplicate_indices_fn = duplicate_indices_fn or duplicate_indices
         self._on_no_duplicates = on_no_duplicates
         self._notice_text = notice_text
+        self._valid_file_types = {ext.lower() for ext in (valid_file_types or [])}
+        self._schedule = schedule or []
+        self._locked_until = int(locked_until)
+        self._current_index = current_index
+        self._validate_files = validate_files
+        self.random_preview = bool(random_preview)
         self.working_files = list(files)
+        self.working_folders = list(folders or [])
+        self._thumbnail_cache = {}
+        self._pending_thumbnail_rows = []
+        self._pending_thumbnail_keys = set()
+        self._thumbnail_generation = 0
+        self._placeholder_icon = self._build_placeholder_icon()
+        self._thumbnail_timer = QtCore.QTimer(self)
+        self._thumbnail_timer.setSingleShot(False)
+        self._thumbnail_timer.timeout.connect(self._load_next_thumbnail_batch)
 
         self._setup_ui()
         self._connect_signals()
@@ -45,34 +85,86 @@ class ImageManagerDialog(QtWidgets.QDialog):
             )
             root_layout.addWidget(self.notice_label)
 
+        if self.random_preview:
+            self.random_label = QtWidgets.QLabel(
+                "Randomized preview. Apply will lock this order and turn randomization off.",
+                self,
+            )
+            self.random_label.setWordWrap(True)
+            self.random_label.setStyleSheet(
+                "background: rgb(32, 57, 68); color: rgb(184, 232, 245);"
+                " border: 1px solid rgb(78, 137, 153); border-radius: 4px;"
+                " padding: 8px;"
+            )
+            root_layout.addWidget(self.random_label)
+
         self.search_input = QtWidgets.QLineEdit(self)
         self.search_input.setPlaceholderText("Filter by filename or path...")
         root_layout.addWidget(self.search_input)
 
-        self.images_list = QtWidgets.QListWidget(self)
+        content_layout = QtWidgets.QHBoxLayout()
+        self.images_list = OrderListWidget(self)
         self.images_list.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
         self.images_list.setAlternatingRowColors(True)
-        root_layout.addWidget(self.images_list, stretch=1)
+        self.images_list.setIconSize(QtCore.QSize(72, 72))
+        self.images_list.setUniformItemSizes(True)
+        self.images_list.setDragDropMode(QtWidgets.QAbstractItemView.InternalMove)
+        self.images_list.setDefaultDropAction(QtCore.Qt.MoveAction)
+        content_layout.addWidget(self.images_list, stretch=2)
+
+        details = QtWidgets.QVBoxLayout()
+        self.preview_label = QtWidgets.QLabel(self)
+        self.preview_label.setMinimumSize(QtCore.QSize(280, 280))
+        self.preview_label.setAlignment(QtCore.Qt.AlignCenter)
+        self.preview_label.setStyleSheet(
+            "background: rgb(18, 32, 43); border: 1px solid rgb(77, 105, 121);"
+        )
+        self.preview_label.setText("No image selected")
+        details.addWidget(self.preview_label)
+
+        self.details_label = QtWidgets.QLabel(self)
+        self.details_label.setWordWrap(True)
+        self.details_label.setTextInteractionFlags(
+            QtCore.Qt.TextSelectableByMouse | QtCore.Qt.TextSelectableByKeyboard
+        )
+        details.addWidget(self.details_label)
+        details.addStretch(1)
+        content_layout.addLayout(details, stretch=1)
+        root_layout.addLayout(content_layout, stretch=1)
 
         self.info_label = QtWidgets.QLabel(self)
         root_layout.addWidget(self.info_label)
 
         controls = QtWidgets.QHBoxLayout()
+        self.add_files_btn = QtWidgets.QPushButton("Add Files", self)
+        self.add_folder_btn = QtWidgets.QPushButton("Add Folder", self)
         self.remove_selected_btn = QtWidgets.QPushButton("Remove Selected", self)
         self.remove_missing_btn = QtWidgets.QPushButton("Remove Missing", self)
         self.show_duplicates_btn = QtWidgets.QPushButton("Show Duplicates", self)
         self.show_duplicates_btn.setCheckable(True)
         self.move_up_btn = QtWidgets.QPushButton("Move Up", self)
         self.move_down_btn = QtWidgets.QPushButton("Move Down", self)
+        self.move_top_btn = QtWidgets.QPushButton("Move Top", self)
+        self.move_bottom_btn = QtWidgets.QPushButton("Move Bottom", self)
+        self.shuffle_btn = QtWidgets.QPushButton("Shuffle", self)
+        self.sort_name_btn = QtWidgets.QPushButton("Sort Name", self)
+        self.sort_path_btn = QtWidgets.QPushButton("Sort Path", self)
         self.open_folder_btn = QtWidgets.QPushButton("Open Folder", self)
         self.clear_all_btn = QtWidgets.QPushButton("Clear All", self)
 
         for widget in (
+            self.add_files_btn,
+            self.add_folder_btn,
             self.remove_selected_btn,
             self.remove_missing_btn,
             self.show_duplicates_btn,
             self.move_up_btn,
             self.move_down_btn,
+            self.move_top_btn,
+            self.move_bottom_btn,
+            self.shuffle_btn,
+            self.sort_name_btn,
+            self.sort_path_btn,
             self.open_folder_btn,
             self.clear_all_btn,
         ):
@@ -87,17 +179,177 @@ class ImageManagerDialog(QtWidgets.QDialog):
         root_layout.addWidget(self.dialog_buttons)
 
     def _connect_signals(self):
+        self.add_files_btn.clicked.connect(self._add_files)
+        self.add_folder_btn.clicked.connect(self._add_folder)
         self.remove_selected_btn.clicked.connect(self._remove_selected)
         self.remove_missing_btn.clicked.connect(self._remove_missing)
         self.show_duplicates_btn.toggled.connect(self._toggle_show_duplicates)
         self.move_up_btn.clicked.connect(lambda: self._move_selected(-1))
         self.move_down_btn.clicked.connect(lambda: self._move_selected(1))
+        self.move_top_btn.clicked.connect(lambda: self._move_to_edge(-1))
+        self.move_bottom_btn.clicked.connect(lambda: self._move_to_edge(1))
+        self.shuffle_btn.clicked.connect(self._shuffle_unlocked)
+        self.sort_name_btn.clicked.connect(lambda: self._sort_unlocked("name"))
+        self.sort_path_btn.clicked.connect(lambda: self._sort_unlocked("path"))
         self.open_folder_btn.clicked.connect(self._open_selected_folder)
         self.clear_all_btn.clicked.connect(self._clear_all)
         self.search_input.textChanged.connect(self._refresh_list)
+        self.images_list.currentItemChanged.connect(self._update_preview)
+        self.images_list.verticalScrollBar().valueChanged.connect(
+            self._queue_visible_thumbnails
+        )
+        self.images_list.verticalScrollBar().rangeChanged.connect(
+            lambda _minimum, _maximum: self._queue_visible_thumbnails()
+        )
 
         self.dialog_buttons.accepted.connect(self.accept)
         self.dialog_buttons.rejected.connect(self.reject)
+
+    def accept(self):
+        if self._validate_files:
+            message = self._validate_files(self.working_files)
+            if message:
+                QtWidgets.QMessageBox.warning(self, "Cannot Apply Order", message)
+                return
+        super().accept()
+
+    def _is_locked_index(self, index):
+        if index < 0 or index >= len(self.working_files):
+            return True
+        return index <= self._locked_until or self.working_files[index] == BREAK_IMAGE_PATH
+
+    def _build_placeholder_icon(self):
+        pixmap = QtGui.QPixmap(72, 72)
+        pixmap.fill(QtGui.QColor("#253847"))
+        painter = QtGui.QPainter(pixmap)
+        painter.setPen(QtGui.QColor("#8fb5c4"))
+        painter.drawRect(10, 12, 52, 48)
+        painter.drawLine(16, 50, 30, 36)
+        painter.drawLine(30, 36, 42, 48)
+        painter.drawLine(42, 48, 56, 30)
+        painter.end()
+        return QtGui.QIcon(pixmap)
+
+    def _scaled_pixmap_for_path(self, file_path, target_size):
+        if file_path == BREAK_IMAGE_PATH or not os.path.exists(file_path):
+            return QtGui.QPixmap()
+
+        reader = QtGui.QImageReader(file_path)
+        reader.setAutoTransform(True)
+        source_size = reader.size()
+        if source_size.isValid() and not source_size.isEmpty():
+            scaled_size = source_size.scaled(
+                target_size, QtCore.Qt.KeepAspectRatio
+            )
+            reader.setScaledSize(scaled_size)
+
+        image = reader.read()
+        if image.isNull():
+            return QtGui.QPixmap()
+        pixmap = QtGui.QPixmap.fromImage(image)
+        if pixmap.isNull():
+            return QtGui.QPixmap()
+        if pixmap.width() > target_size.width() or pixmap.height() > target_size.height():
+            pixmap = pixmap.scaled(
+                target_size,
+                QtCore.Qt.KeepAspectRatio,
+                QtCore.Qt.SmoothTransformation,
+            )
+        return pixmap
+
+    def _thumbnail_for_path(self, file_path):
+        if file_path in self._thumbnail_cache:
+            return self._thumbnail_cache[file_path]
+        return self._placeholder_icon
+
+    def _queue_thumbnail(self, row, file_path):
+        if (
+            file_path == BREAK_IMAGE_PATH
+            or file_path in self._thumbnail_cache
+            or not os.path.exists(file_path)
+        ):
+            return
+        key = (self._thumbnail_generation, row, file_path)
+        if key in self._pending_thumbnail_keys:
+            return
+        self._pending_thumbnail_keys.add(key)
+        self._pending_thumbnail_rows.append(key)
+
+    def _start_thumbnail_loading(self):
+        if self._pending_thumbnail_rows:
+            self._thumbnail_timer.start(15)
+        else:
+            self._thumbnail_timer.stop()
+
+    def _visible_row_range(self):
+        count = self.images_list.count()
+        if count <= 0:
+            return None
+
+        viewport = self.images_list.viewport()
+        top_index = self.images_list.indexAt(QtCore.QPoint(0, 0))
+        bottom_index = self.images_list.indexAt(
+            QtCore.QPoint(0, max(0, viewport.height() - 1))
+        )
+
+        first = top_index.row() if top_index.isValid() else 0
+        if bottom_index.isValid():
+            last = bottom_index.row()
+        else:
+            row_height = max(1, self.images_list.sizeHintForRow(first))
+            visible_rows = max(12, viewport.height() // row_height + 1)
+            last = first + visible_rows
+
+        buffer_rows = 10
+        first = max(0, first - buffer_rows)
+        last = min(count - 1, last + buffer_rows)
+        return first, last
+
+    def _queue_visible_thumbnails(self):
+        row_range = self._visible_row_range()
+        if row_range is None:
+            return
+        first, last = row_range
+        for row in range(first, last + 1):
+            item = self.images_list.item(row)
+            if item is None:
+                continue
+            self._queue_thumbnail(row, item.data(QtCore.Qt.UserRole + 1))
+        self._start_thumbnail_loading()
+
+    def _load_next_thumbnail_batch(self):
+        batch_size = 2
+        target_size = QtCore.QSize(72, 72)
+        loaded = 0
+        while self._pending_thumbnail_rows and loaded < batch_size:
+            generation, row, file_path = self._pending_thumbnail_rows.pop(0)
+            self._pending_thumbnail_keys.discard((generation, row, file_path))
+            if generation != self._thumbnail_generation:
+                continue
+            pixmap = self._scaled_pixmap_for_path(file_path, target_size)
+            if pixmap.isNull():
+                continue
+            icon = QtGui.QIcon(pixmap)
+            self._thumbnail_cache[file_path] = icon
+            if row < self.images_list.count():
+                item = self.images_list.item(row)
+                if item and item.data(QtCore.Qt.UserRole + 1) == file_path:
+                    item.setIcon(icon)
+            loaded += 1
+        if not self._pending_thumbnail_rows:
+            self._thumbnail_timer.stop()
+
+    def _sync_working_files_from_list(self):
+        if self.search_input.text().strip():
+            self._refresh_list()
+            return
+        ordered = []
+        for row in range(self.images_list.count()):
+            item = self.images_list.item(row)
+            ordered.append(item.data(QtCore.Qt.UserRole + 1))
+        if len(ordered) == len(self.working_files):
+            self.working_files = ordered
+        self._refresh_list()
 
     def _selected_indices(self):
         return sorted(
@@ -114,15 +366,31 @@ class ImageManagerDialog(QtWidgets.QDialog):
             item = self.images_list.item(row)
             if item.data(QtCore.Qt.UserRole) in keep:
                 item.setSelected(True)
+                self.images_list.setCurrentItem(item)
 
     def _refresh_list(self):
+        self._thumbnail_timer.stop()
+        self._pending_thumbnail_rows = []
+        self._pending_thumbnail_keys = set()
+        self._thumbnail_generation += 1
         query = self.search_input.text().strip().lower()
         self.images_list.clear()
+        has_locked_rows = any(
+            self._is_locked_index(index) for index in range(len(self.working_files))
+        )
+        self.images_list.setDragDropMode(
+            QtWidgets.QAbstractItemView.NoDragDrop
+            if query or has_locked_rows
+            else QtWidgets.QAbstractItemView.InternalMove
+        )
         visible = 0
-        missing = 0
 
         duplicate_indices = self._duplicate_indices_fn(self.working_files)
         show_duplicates = self.show_duplicates_btn.isChecked()
+        scheduled_count = selection_stats(
+            self.working_files, self.working_folders, self._schedule
+        ).scheduled_images
+        real_seen = 0
 
         for index, file_path in enumerate(self.working_files):
             path_lower = file_path.lower()
@@ -130,41 +398,159 @@ class ImageManagerDialog(QtWidgets.QDialog):
             if query and query not in path_lower and query not in base_lower:
                 continue
 
-            item_text = file_path
+            is_break = file_path == BREAK_IMAGE_PATH
             is_duplicate = index in duplicate_indices
+            is_locked = self._is_locked_index(index)
+            is_current = self._current_index == index
+            if not is_break:
+                real_seen += 1
+
+            markers = []
+            if is_break:
+                markers.append("BREAK")
+            elif scheduled_count and real_seen <= scheduled_count:
+                markers.append("SCHEDULED")
+            if is_current:
+                markers.append("CURRENT")
+            if is_locked:
+                markers.append("LOCKED")
             if show_duplicates and is_duplicate:
-                item_text = f"{item_text}  |  DUPLICATE"
+                markers.append("DUPLICATE")
+            if file_path != BREAK_IMAGE_PATH and not os.path.exists(file_path):
+                markers.append("MISSING")
 
-            item = QtWidgets.QListWidgetItem(item_text)
+            display_name = "Break" if is_break else os.path.basename(file_path)
+            marker_text = f"  |  {' / '.join(markers)}" if markers else ""
+            item_text = f"{index + 1:03d}. {display_name}{marker_text}\n{file_path}"
+
+            item = QtWidgets.QListWidgetItem(self._thumbnail_for_path(file_path), item_text)
             item.setData(QtCore.Qt.UserRole, index)
+            item.setData(QtCore.Qt.UserRole + 1, file_path)
 
-            if not os.path.exists(file_path):
-                missing += 1
+            if is_locked:
+                item.setForeground(QtGui.QBrush(QtGui.QColor("#b8c4cc")))
+            if file_path != BREAK_IMAGE_PATH and not os.path.exists(file_path):
                 item.setForeground(QtGui.QBrush(QtGui.QColor("#ff7f7f")))
             elif show_duplicates and is_duplicate:
                 item.setBackground(QtGui.QBrush(QtGui.QColor("#40361e")))
                 item.setForeground(QtGui.QBrush(QtGui.QColor("#f5d47a")))
+            elif is_current:
+                item.setBackground(QtGui.QBrush(QtGui.QColor("#1d4a55")))
 
             self.images_list.addItem(item)
             visible += 1
 
-        duplicates_total = len(duplicate_indices)
-        self.info_label.setText(
-            f"Visible: {visible}  |  Total: {len(self.working_files)}  |  Missing: {missing}"
-            f"  |  Duplicates: {duplicates_total}"
+        stats = selection_stats(self.working_files, self.working_folders, self._schedule)
+        ext_bits = ", ".join(f"{ext}:{count}" for ext, count in stats.extension_counts.items())
+        schedule_bits = (
+            f"  |  Scheduled: {stats.scheduled_images}"
+            f"  |  Extra: {stats.extra_images}"
+            f"  |  Short: {stats.shortage_images}"
+            if stats.scheduled_images
+            else ""
         )
+        self.info_label.setText(
+            f"Visible: {visible}  |  Total: {stats.total_files}"
+            f"  |  Folders: {stats.folder_count}"
+            f"{schedule_bits}"
+            f"  |  Missing: {stats.missing_files}"
+            f"  |  Duplicates: {stats.duplicate_files}"
+            f"  |  Types: {ext_bits or 'none'}"
+        )
+        self._update_preview(self.images_list.currentItem(), None)
+        QtCore.QTimer.singleShot(0, self._queue_visible_thumbnails)
+
+    def _update_preview(self, current, previous=None):
+        if current is None:
+            self.preview_label.setPixmap(QtGui.QPixmap())
+            self.preview_label.setText("No image selected")
+            self.details_label.setText("")
+            return
+
+        index = current.data(QtCore.Qt.UserRole)
+        file_path = current.data(QtCore.Qt.UserRole + 1)
+        if file_path == BREAK_IMAGE_PATH:
+            self.preview_label.setPixmap(QtGui.QPixmap())
+            self.preview_label.setText("Break")
+            self.details_label.setText(f"Order: {index + 1}\nInternal break marker")
+            return
+
+        target_size = self.preview_label.size()
+        if not target_size.isValid() or target_size.isEmpty():
+            target_size = QtCore.QSize(280, 280)
+        pixmap = self._scaled_pixmap_for_path(file_path, target_size)
+        if pixmap.isNull():
+            self.preview_label.setPixmap(QtGui.QPixmap())
+            self.preview_label.setText("Preview unavailable")
+            dimensions = "unknown"
+        else:
+            self.preview_label.setText("")
+            self.preview_label.setPixmap(
+                pixmap.scaled(
+                    target_size,
+                    QtCore.Qt.KeepAspectRatio,
+                    QtCore.Qt.SmoothTransformation,
+                )
+            )
+            dimensions = f"{pixmap.width()} x {pixmap.height()}"
+
+        size_text = "missing"
+        try:
+            size_text = f"{Path(file_path).stat().st_size / 1024:.1f} KB"
+        except OSError:
+            pass
+        self.details_label.setText(
+            f"Order: {index + 1}\n"
+            f"Name: {os.path.basename(file_path)}\n"
+            f"Dimensions: {dimensions}\n"
+            f"Size: {size_text}\n"
+            f"Path: {file_path}"
+        )
+
+    def _check_files(self, files):
+        valid = []
+        for file_path in files:
+            ext = os.path.splitext(file_path)[1].lower()
+            if self._valid_file_types and ext not in self._valid_file_types:
+                continue
+            if os.path.isfile(file_path):
+                valid.append(file_path)
+        return valid
+
+    def _add_files(self):
+        selected, _ = QtWidgets.QFileDialog.getOpenFileNames(self, "Add Images")
+        valid = self._check_files(selected)
+        if valid:
+            self.working_files.extend(valid)
+            self._refresh_list()
+
+    def _add_folder(self):
+        directory = QtWidgets.QFileDialog.getExistingDirectory(self, "Add Folder")
+        if not directory:
+            return
+        if directory not in self.working_folders:
+            self.working_folders.append(directory)
+        added = []
+        for root, _dirs, files in os.walk(directory):
+            added.extend(self._check_files([os.path.join(root, name) for name in files]))
+        self.working_files.extend(added)
+        self._refresh_list()
 
     def _remove_selected(self):
         indices = self._selected_indices()
         if not indices:
             return
         for index in reversed(indices):
-            if 0 <= index < len(self.working_files):
+            if 0 <= index < len(self.working_files) and not self._is_locked_index(index):
                 self.working_files.pop(index)
         self._refresh_list()
 
     def _remove_missing(self):
-        self.working_files = [path for path in self.working_files if os.path.exists(path)]
+        self.working_files = [
+            path
+            for index, path in enumerate(self.working_files)
+            if self._is_locked_index(index) or path == BREAK_IMAGE_PATH or os.path.exists(path)
+        ]
         self._refresh_list()
 
     def _move_selected(self, direction):
@@ -174,7 +560,12 @@ class ImageManagerDialog(QtWidgets.QDialog):
 
         if direction < 0:
             for index in indices:
-                if index <= 0 or index - 1 in indices:
+                if (
+                    index <= 0
+                    or index - 1 in indices
+                    or self._is_locked_index(index)
+                    or self._is_locked_index(index - 1)
+                ):
                     continue
                 self.working_files[index - 1], self.working_files[index] = (
                     self.working_files[index],
@@ -183,7 +574,12 @@ class ImageManagerDialog(QtWidgets.QDialog):
             new_indices = [max(0, i - 1) for i in indices]
         else:
             for index in reversed(indices):
-                if index >= len(self.working_files) - 1 or index + 1 in indices:
+                if (
+                    index >= len(self.working_files) - 1
+                    or index + 1 in indices
+                    or self._is_locked_index(index)
+                    or self._is_locked_index(index + 1)
+                ):
                     continue
                 self.working_files[index + 1], self.working_files[index] = (
                     self.working_files[index],
@@ -193,6 +589,40 @@ class ImageManagerDialog(QtWidgets.QDialog):
 
         self._refresh_list()
         self._reselect_indices(new_indices)
+
+    def _move_to_edge(self, direction):
+        previous = None
+        while previous != self.working_files:
+            previous = list(self.working_files)
+            self._move_selected(direction)
+
+    def _unlocked_indices(self):
+        return [
+            index
+            for index in range(len(self.working_files))
+            if not self._is_locked_index(index)
+        ]
+
+    def _replace_unlocked(self, ordered_paths):
+        unlocked = self._unlocked_indices()
+        for index, path in zip(unlocked, ordered_paths):
+            self.working_files[index] = path
+        self._refresh_list()
+
+    def _shuffle_unlocked(self):
+        import random
+
+        paths = [self.working_files[index] for index in self._unlocked_indices()]
+        random.shuffle(paths)
+        self._replace_unlocked(paths)
+
+    def _sort_unlocked(self, mode):
+        paths = [self.working_files[index] for index in self._unlocked_indices()]
+        if mode == "name":
+            paths.sort(key=lambda path: os.path.basename(path).lower())
+        else:
+            paths.sort(key=lambda path: path.lower())
+        self._replace_unlocked(paths)
 
     def _open_selected_folder(self):
         indices = self._selected_indices()
@@ -207,7 +637,9 @@ class ImageManagerDialog(QtWidgets.QDialog):
             )
 
     def _clear_all(self):
-        self.working_files.clear()
+        self.working_files = [
+            path for index, path in enumerate(self.working_files) if self._is_locked_index(index)
+        ]
         self._refresh_list()
 
     def _toggle_show_duplicates(self, checked):
@@ -325,7 +757,7 @@ class ShortcutMapDialog(QtWidgets.QDialog):
 def run_image_manager_dialog(
     parent,
     files,
-    duplicate_indices_fn,
+    duplicate_indices_fn=None,
     on_no_duplicates=None,
     notice_text=None,
 ):
@@ -340,6 +772,18 @@ def run_image_manager_dialog(
     if dialog.exec() != QtWidgets.QDialog.Accepted:
         return None
     return dialog.working_files
+
+
+def run_selection_order_dialog(parent, files, **kwargs):
+    """Open selection order viewer and return updated files/folders when accepted."""
+    dialog = ImageManagerDialog(parent=parent, files=files, **kwargs)
+    if dialog.exec() != QtWidgets.QDialog.Accepted:
+        return None
+    return {
+        "files": dialog.working_files,
+        "folders": dialog.working_folders,
+        "random_preview": dialog.random_preview,
+    }
 
 
 def run_shortcut_map_dialog(parent, shortcut_rows):

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,30 +1,42 @@
 # GestureSesh Test Suite
 
-This directory contains automated tests for the GestureSesh application.
+This directory contains automated tests for GestureSesh. Most tests are pytest-compatible Python tests; a few packaging checks are platform-specific shell scripts.
 
-## Update Checker Tests
+## Running Tests
 
-### Core Files
-- **`test_update_checker.py`** - Comprehensive test suite for UpdateChecker functionality
-  - `TestUpdateCheckerChangelog` - Tests for changelog parsing and content extraction
-  - `TestUpdateCheckerCore` - Tests for core update checking logic (version comparison, network handling, etc.)
-- **`test_update_checker_suite.py`** - Test runner with multiple modes and debug capabilities
-- **`debug_changelog.py`** - Interactive debug utility for changelog analysis
-
-### Running Tests
-
-#### Individual Test File
 ```bash
-# Run with pytest (recommended)
-python -m pytest tests/test_update_checker.py -v
+# Full Python test suite
+python -m pytest -q
 
-# Run directly
-python tests/test_update_checker.py
+# Focused app/session tests
+python -m pytest tests/test_gesturesesh.py -q
+python -m pytest tests/test_selection_order.py -q
+python -m pytest tests/test_session_shortcuts.py -q
+python -m pytest tests/test_session_image_loader.py -q
+python -m pytest tests/test_scan_directories.py -q
+
+# GUI smoke flow
+python tools/smoke_gui_test.py
 ```
 
-#### Test Suite Runner
+## Test Layout
+
+- `test_gesturesesh.py` - MainApp logic and session orchestration tests that share the larger mocked main-window fixture.
+- `test_selection_order.py` - Selection order helpers and Selection Order Viewer dialog mutation/performance rules.
+- `test_session_shortcuts.py` - Session display shortcut ownership and shortcut-map registration.
+- `test_session_image_loader.py` - Session image loader cache behavior and dtype normalization.
+- `test_scan_directories.py` - Directory scanning behavior, symlink handling, duplicate filtering, and file type checks.
+- `test_update_checker.py` - UpdateChecker changelog parsing, version checks, network handling, and config behavior.
+- `test_update_checker_suite.py` - Update checker runner with unit, integration, debug, and no-network modes.
+- `debug_changelog.py` - Interactive changelog parsing/debug utility.
+- `test_app_launch.sh` - Bash launch check.
+- `test_dmg.sh` - macOS DMG packaging check.
+- `test_windows_build.ps1` - Windows build check.
+
+## Update Checker Runner
+
 ```bash
-# Run all tests
+# Run all update-checker modes without network access
 python tests/test_update_checker_suite.py --mode all --no-network
 
 # Run only unit tests
@@ -37,28 +49,9 @@ python tests/test_update_checker_suite.py --mode debug
 python tests/test_update_checker_suite.py --mode integration
 ```
 
-#### Debug Utility
-```bash
-# Interactive changelog debugging
-python tests/debug_changelog.py
-```
+## Coverage Notes
 
-### Test Coverage
-- ✅ Changelog parsing (multiple formats)
-- ✅ Version comparison logic
-- ✅ Network error handling
-- ✅ Configuration management
-- ✅ Update detection workflow
-- ✅ Content extraction and formatting
-
-## Other Tests
-- `test_gesturesesh.py` - Main application tests
-- `test_scan_directories.py` - Directory scanning functionality
-- `test_app_launch.sh` - Application launch tests (bash)
-- `test_dmg.sh` - macOS DMG packaging tests (bash)
-- `test_windows_build.ps1` - Windows build tests (PowerShell)
-
-## Notes
-- Update checker tests use local `CHANGELOG.md` file for testing
-- Network tests can be skipped with `--no-network` flag
-- All tests pass and provide comprehensive coverage of update functionality
+- Core selection-order behavior is covered by pure helper tests and dialog logic tests.
+- Thumbnail loading has a regression test to ensure the viewer queues only visible rows plus a small buffer, instead of loading every selected image at once.
+- Main/session behavior is covered at the orchestration level with mocked Qt widgets; manual QA is still useful for subjective UI smoothness with very large real image libraries.
+- Update checker tests use the local `CHANGELOG.md`; network-dependent checks can be skipped with `--no-network`.

--- a/tests/test_gesturesesh.py
+++ b/tests/test_gesturesesh.py
@@ -6,12 +6,10 @@ import sys
 import unittest
 import tempfile
 import shutil
-import random
 from unittest.mock import patch, MagicMock  # for explicit mock call reference
 import types
 from pathlib import Path
-from collections import Counter, OrderedDict
-import numpy as np
+from collections import Counter
 from PyQt5 import QtWidgets
 from PyQt5.QtWidgets import QApplication
 
@@ -24,143 +22,9 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(
 
 from gesturesesh.main import MainApp
 from gesturesesh.session_window import SessionDisplay, BREAK_IMAGE_PATH
-from gesturesesh.session.image_loader import SessionImageLoaderMixin
 from gesturesesh.app.models import ScheduleEntry
 from gesturesesh.utils.time import format_seconds
 from gesturesesh.ui.main_window import Ui_MainWindow
-from gesturesesh.ui.session_display import Ui_session_display
-
-
-class TestSessionDisplayShortcuts(unittest.TestCase):
-    def test_filter_buttons_do_not_own_window_shortcuts(self):
-        widget = QtWidgets.QWidget()
-        ui = Ui_session_display()
-        ui.setupUi(widget)
-
-        self.assertTrue(ui.grayscale_button.shortcut().isEmpty())
-        self.assertTrue(ui.flip_horizontal_button.shortcut().isEmpty())
-        self.assertTrue(ui.flip_vertical_button.shortcut().isEmpty())
-
-    def test_filter_shortcuts_are_registered_on_session_window(self):
-        class DummySession(QtWidgets.QWidget):
-            pass
-
-        dummy = DummySession()
-        callback_names = [
-            "toggle_resize",
-            "toggle_always_on_top",
-            "toggle_mute",
-            "add_30_seconds",
-            "add_60_seconds",
-            "restart_timer",
-            "skip_image",
-            "toggle_frameless",
-            "toggle_fullscreen_frameless",
-            "increase_brightness",
-            "decrease_brightness",
-            "increase_contrast",
-            "decrease_contrast",
-            "toggle_threshold",
-            "toggle_edge",
-            "reset_image_mods",
-            "toggle_grayscale_mode",
-            "grayscale",
-            "flip_horizontal",
-            "flip_vertical",
-            "open_image_directory",
-            "toggle_zoom_enabled",
-            "reset_zoom_to_default",
-            "quick_inspect",
-            "toggle_zoom_reset_mode",
-            "open_shortcut_map",
-        ]
-        for name in callback_names:
-            setattr(dummy, name, lambda: None)
-
-        SessionDisplay.init_shortcuts(dummy)
-
-        self.assertEqual(dummy.grayscale_shortcut.key().toString(), "G")
-        self.assertEqual(dummy.flip_horizontal_shortcut.key().toString(), "H")
-        self.assertEqual(dummy.flip_vertical_shortcut.key().toString(), "V")
-        self.assertEqual(dummy.frameless_fullscreen.key().toString(), "Ctrl+Shift+F")
-
-
-class TestSessionImageLoaderMixin(unittest.TestCase):
-    def test_prepare_image_mods_uses_animation_cache_and_starts_timer(self):
-        frame = np.zeros((2, 2, 4), dtype=np.uint8)
-        fake = types.SimpleNamespace(
-            playlist=["animated.gif"],
-            playlist_position=0,
-            image_mods={"break": False},
-            animation_cache=OrderedDict(),
-            still_image_cache=OrderedDict(),
-            max_animation_cache_entries=12,
-            max_still_cache_entries=64,
-            animation_timer=MagicMock(),
-            animation_frames=[],
-            animation_durations_ms=[],
-            animation_frame_index=0,
-            animation_source_path=None,
-            reset_animation_state=MagicMock(),
-            load_animation_frames=MagicMock(return_value=([frame, frame.copy()], [80, 90])),
-            _render_cvimage=MagicMock(),
-        )
-        fake._cache_get = lambda cache, key: SessionDisplay._cache_get(fake, cache, key)
-        fake._cache_put = lambda cache, key, value, limit: SessionDisplay._cache_put(
-            fake, cache, key, value, limit
-        )
-
-        SessionImageLoaderMixin.prepare_image_mods(fake)
-        SessionImageLoaderMixin.prepare_image_mods(fake)
-
-        fake.load_animation_frames.assert_called_once_with("animated.gif")
-        assert fake.animation_source_path == "animated.gif"
-        assert len(fake.animation_frames) == 2
-        assert fake._render_cvimage.call_count == 2
-        fake.animation_timer.start.assert_called_with(80)
-
-    def test_prepare_image_mods_falls_back_to_still_cache(self):
-        image = np.ones((2, 2, 3), dtype=np.uint8)
-        fake = types.SimpleNamespace(
-            playlist=["still.jpg"],
-            playlist_position=0,
-            image_mods={"break": False},
-            animation_cache=OrderedDict(),
-            still_image_cache=OrderedDict(),
-            max_animation_cache_entries=12,
-            max_still_cache_entries=64,
-            reset_animation_state=MagicMock(),
-            load_animation_frames=MagicMock(return_value=None),
-            decode_current_image=MagicMock(return_value=image),
-            _render_cvimage=MagicMock(),
-        )
-        fake._cache_get = lambda cache, key: SessionDisplay._cache_get(fake, cache, key)
-        fake._cache_put = lambda cache, key, value, limit: SessionDisplay._cache_put(
-            fake, cache, key, value, limit
-        )
-
-        SessionImageLoaderMixin.prepare_image_mods(fake)
-        SessionImageLoaderMixin.prepare_image_mods(fake)
-
-        fake.decode_current_image.assert_called_once()
-        assert fake._render_cvimage.call_count == 2
-
-    def test_normalize_cvimage_dtype_scales_common_image_depths(self):
-        fake = types.SimpleNamespace()
-
-        bool_image = np.array([[True, False]])
-        uint16_image = np.array([[0, 1023]], dtype=np.uint16)
-        float_image = np.array([[0.0, 1.0]], dtype=np.float32)
-
-        assert SessionImageLoaderMixin.normalize_cvimage_dtype(fake, bool_image).tolist() == [
-            [255, 0]
-        ]
-        assert SessionImageLoaderMixin.normalize_cvimage_dtype(
-            fake, uint16_image
-        ).tolist() == [[0, 255]]
-        assert SessionImageLoaderMixin.normalize_cvimage_dtype(
-            fake, float_image
-        ).tolist() == [[0, 255]]
 
 
 def mock_main_app_setup_ui(self, main_window):
@@ -173,18 +37,7 @@ def mock_main_app_setup_ui(self, main_window):
     self.set_minutes = MagicMock(spec=QtWidgets.QSpinBox)
     self.set_seconds = MagicMock(spec=QtWidgets.QSpinBox)
     self.dialog_buttons = MagicMock(spec=QtWidgets.QDialogButtonBox)
-def mock_session_display_setup_ui(self, session_display_window):
-    """Mocks the SessionDisplay's setupUi, creating all necessary widgets."""
-    self.image_display = MagicMock(spec=QtWidgets.QLabel)
-    self.timer_display = MagicMock(spec=QtWidgets.QLabel)
-    self.session_info = MagicMock(spec=QtWidgets.QLabel)
-    self.previous_image = MagicMock(spec=QtWidgets.QPushButton)
-    self.pause_timer = MagicMock(spec=QtWidgets.QPushButton)
-    self.stop_session = MagicMock(spec=QtWidgets.QPushButton)
-    self.next_image = MagicMock(spec=QtWidgets.QPushButton)
-    self.grayscale_button = MagicMock(spec=QtWidgets.QPushButton)
-    self.flip_horizontal_button = MagicMock(spec=QtWidgets.QPushButton)
-    self.flip_vertical_button = MagicMock(spec=QtWidgets.QPushButton)
+
 
 # ----------------- Helpers to stub MainApp methods for logic-only tests -----------------
 def _stub_save(self):

--- a/tests/test_selection_order.py
+++ b/tests/test_selection_order.py
@@ -1,0 +1,150 @@
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import random
+import sys
+import tempfile
+import unittest
+from collections import Counter
+from pathlib import Path
+
+from PyQt5 import QtGui
+from PyQt5.QtWidgets import QApplication
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src")
+)
+
+app = QApplication.instance()
+if app is None:
+    app = QApplication(sys.argv)
+
+from gesturesesh.app.models import ScheduleEntry
+from gesturesesh.app.selection_order import (
+    effective_selection_order,
+    playlist_with_breaks,
+    remaining_required_images,
+    selection_stats,
+)
+from gesturesesh.session_window import BREAK_IMAGE_PATH
+from gesturesesh.ui.dialogs import ImageManagerDialog
+
+
+class TestSelectionOrderHelpers(unittest.TestCase):
+    def test_effective_selection_order_randomizes_copy(self):
+        items = ["a.jpg", "b.jpg", "c.jpg"]
+        rng = random.Random(10)
+        ordered = effective_selection_order(items, randomize=True, rng=rng)
+
+        assert items == ["a.jpg", "b.jpg", "c.jpg"]
+        assert Counter(ordered) == Counter(items)
+
+    def test_playlist_with_breaks_does_not_mutate_files(self):
+        items = ["a.jpg", "b.jpg", "c.jpg"]
+        schedule = [
+            ScheduleEntry(images=2, time=30),
+            ScheduleEntry(images=0, time=15),
+            ScheduleEntry(images=1, time=30),
+        ]
+
+        playlist = playlist_with_breaks(items, schedule)
+
+        assert items == ["a.jpg", "b.jpg", "c.jpg"]
+        assert playlist == ["a.jpg", "b.jpg", BREAK_IMAGE_PATH, "c.jpg"]
+
+    def test_selection_stats_counts_missing_duplicates_and_schedule(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            existing = os.path.join(tempdir, "image.JPG")
+            Path(existing).touch()
+            missing = os.path.join(tempdir, "missing.png")
+            files = [existing, existing, missing]
+            schedule = [ScheduleEntry(images=4, time=30)]
+
+            stats = selection_stats(files, folders=[tempdir], schedule=schedule)
+
+            assert stats.total_files == 3
+            assert stats.folder_count == 1
+            assert stats.scheduled_images == 4
+            assert stats.shortage_images == 1
+            assert stats.missing_files == 1
+            assert stats.duplicate_files == 1
+            assert stats.extension_counts[".jpg"] == 2
+            assert stats.extension_counts[".png"] == 1
+
+    def test_remaining_required_images_counts_from_current_position(self):
+        schedule = [
+            ScheduleEntry(images=2, time=30),
+            ScheduleEntry(images=0, time=15),
+            ScheduleEntry(images=2, time=30),
+        ]
+        playlist = ["a.jpg", "b.jpg", BREAK_IMAGE_PATH, "c.jpg", "d.jpg"]
+
+        assert remaining_required_images(schedule, playlist, 0) == 4
+        assert remaining_required_images(schedule, playlist, 2) == 2
+        assert remaining_required_images(schedule, playlist, 3) == 2
+
+
+class TestImageManagerDialogLogic(unittest.TestCase):
+    def test_move_buttons_reorder_unlocked_selection(self):
+        dialog = ImageManagerDialog(
+            parent=None,
+            files=["a.jpg", "b.jpg", "c.jpg"],
+            valid_file_types={".jpg"},
+        )
+        dialog._reselect_indices([1])
+
+        dialog._move_selected(-1)
+        assert dialog.working_files == ["b.jpg", "a.jpg", "c.jpg"]
+
+        dialog._move_to_edge(1)
+        assert dialog.working_files == ["a.jpg", "c.jpg", "b.jpg"]
+
+    def test_locked_and_break_rows_are_not_removed_or_moved(self):
+        dialog = ImageManagerDialog(
+            parent=None,
+            files=["shown.jpg", BREAK_IMAGE_PATH, "upcoming.jpg"],
+            valid_file_types={".jpg"},
+            locked_until=0,
+        )
+        dialog._reselect_indices([0, 1, 2])
+
+        dialog._remove_selected()
+        assert dialog.working_files == ["shown.jpg", BREAK_IMAGE_PATH]
+
+        dialog._reselect_indices([1])
+        dialog._move_selected(-1)
+        assert dialog.working_files == ["shown.jpg", BREAK_IMAGE_PATH]
+
+    def test_check_files_filters_to_supported_existing_images(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            image = os.path.join(tempdir, "image.jpg")
+            text = os.path.join(tempdir, "notes.txt")
+            Path(image).touch()
+            Path(text).touch()
+            dialog = ImageManagerDialog(
+                parent=None,
+                files=[],
+                valid_file_types={".jpg"},
+            )
+
+            assert dialog._check_files([image, text]) == [image]
+
+    def test_thumbnail_queue_is_limited_to_visible_rows(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            image_paths = []
+            image = QtGui.QImage(16, 16, QtGui.QImage.Format_RGB32)
+            image.fill(QtGui.QColor("red"))
+            for index in range(80):
+                path = os.path.join(tempdir, f"image_{index}.png")
+                image.save(path)
+                image_paths.append(path)
+
+            dialog = ImageManagerDialog(
+                parent=None,
+                files=image_paths,
+                valid_file_types={".png"},
+            )
+            dialog._queue_visible_thumbnails()
+
+            assert 0 < len(dialog._pending_thumbnail_rows) < len(image_paths)

--- a/tests/test_session_image_loader.py
+++ b/tests/test_session_image_loader.py
@@ -1,0 +1,103 @@
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+import types
+import unittest
+from collections import OrderedDict
+from unittest.mock import MagicMock
+
+import numpy as np
+from PyQt5.QtWidgets import QApplication
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src")
+)
+
+app = QApplication.instance()
+if app is None:
+    app = QApplication(sys.argv)
+
+from gesturesesh.session.image_loader import SessionImageLoaderMixin
+from gesturesesh.session_window import SessionDisplay
+
+
+class TestSessionImageLoaderMixin(unittest.TestCase):
+    def test_prepare_image_mods_uses_animation_cache_and_starts_timer(self):
+        frame = np.zeros((2, 2, 4), dtype=np.uint8)
+        fake = types.SimpleNamespace(
+            playlist=["animated.gif"],
+            playlist_position=0,
+            image_mods={"break": False},
+            animation_cache=OrderedDict(),
+            still_image_cache=OrderedDict(),
+            max_animation_cache_entries=12,
+            max_still_cache_entries=64,
+            animation_timer=MagicMock(),
+            animation_frames=[],
+            animation_durations_ms=[],
+            animation_frame_index=0,
+            animation_source_path=None,
+            reset_animation_state=MagicMock(),
+            load_animation_frames=MagicMock(
+                return_value=([frame, frame.copy()], [80, 90])
+            ),
+            _render_cvimage=MagicMock(),
+        )
+        fake._cache_get = lambda cache, key: SessionDisplay._cache_get(fake, cache, key)
+        fake._cache_put = lambda cache, key, value, limit: SessionDisplay._cache_put(
+            fake, cache, key, value, limit
+        )
+
+        SessionImageLoaderMixin.prepare_image_mods(fake)
+        SessionImageLoaderMixin.prepare_image_mods(fake)
+
+        fake.load_animation_frames.assert_called_once_with("animated.gif")
+        assert fake.animation_source_path == "animated.gif"
+        assert len(fake.animation_frames) == 2
+        assert fake._render_cvimage.call_count == 2
+        fake.animation_timer.start.assert_called_with(80)
+
+    def test_prepare_image_mods_falls_back_to_still_cache(self):
+        image = np.ones((2, 2, 3), dtype=np.uint8)
+        fake = types.SimpleNamespace(
+            playlist=["still.jpg"],
+            playlist_position=0,
+            image_mods={"break": False},
+            animation_cache=OrderedDict(),
+            still_image_cache=OrderedDict(),
+            max_animation_cache_entries=12,
+            max_still_cache_entries=64,
+            reset_animation_state=MagicMock(),
+            load_animation_frames=MagicMock(return_value=None),
+            decode_current_image=MagicMock(return_value=image),
+            _render_cvimage=MagicMock(),
+        )
+        fake._cache_get = lambda cache, key: SessionDisplay._cache_get(fake, cache, key)
+        fake._cache_put = lambda cache, key, value, limit: SessionDisplay._cache_put(
+            fake, cache, key, value, limit
+        )
+
+        SessionImageLoaderMixin.prepare_image_mods(fake)
+        SessionImageLoaderMixin.prepare_image_mods(fake)
+
+        fake.decode_current_image.assert_called_once()
+        assert fake._render_cvimage.call_count == 2
+
+    def test_normalize_cvimage_dtype_scales_common_image_depths(self):
+        fake = types.SimpleNamespace()
+
+        bool_image = np.array([[True, False]])
+        uint16_image = np.array([[0, 1023]], dtype=np.uint16)
+        float_image = np.array([[0.0, 1.0]], dtype=np.float32)
+
+        assert SessionImageLoaderMixin.normalize_cvimage_dtype(
+            fake, bool_image
+        ).tolist() == [[255, 0]]
+        assert SessionImageLoaderMixin.normalize_cvimage_dtype(
+            fake, uint16_image
+        ).tolist() == [[0, 255]]
+        assert SessionImageLoaderMixin.normalize_cvimage_dtype(
+            fake, float_image
+        ).tolist() == [[0, 255]]

--- a/tests/test_session_shortcuts.py
+++ b/tests/test_session_shortcuts.py
@@ -1,0 +1,76 @@
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+import unittest
+
+from PyQt5 import QtWidgets
+from PyQt5.QtWidgets import QApplication
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src")
+)
+
+app = QApplication.instance()
+if app is None:
+    app = QApplication(sys.argv)
+
+from gesturesesh.session_window import SessionDisplay
+from gesturesesh.ui.session_display import Ui_session_display
+
+
+class TestSessionDisplayShortcuts(unittest.TestCase):
+    def test_filter_buttons_do_not_own_window_shortcuts(self):
+        widget = QtWidgets.QWidget()
+        ui = Ui_session_display()
+        ui.setupUi(widget)
+
+        self.assertTrue(ui.grayscale_button.shortcut().isEmpty())
+        self.assertTrue(ui.flip_horizontal_button.shortcut().isEmpty())
+        self.assertTrue(ui.flip_vertical_button.shortcut().isEmpty())
+
+    def test_filter_shortcuts_are_registered_on_session_window(self):
+        class DummySession(QtWidgets.QWidget):
+            pass
+
+        dummy = DummySession()
+        callback_names = [
+            "toggle_resize",
+            "toggle_always_on_top",
+            "toggle_mute",
+            "add_30_seconds",
+            "add_60_seconds",
+            "restart_timer",
+            "skip_image",
+            "toggle_frameless",
+            "toggle_fullscreen_frameless",
+            "increase_brightness",
+            "decrease_brightness",
+            "increase_contrast",
+            "decrease_contrast",
+            "toggle_threshold",
+            "toggle_edge",
+            "reset_image_mods",
+            "toggle_grayscale_mode",
+            "grayscale",
+            "flip_horizontal",
+            "flip_vertical",
+            "open_image_directory",
+            "toggle_zoom_enabled",
+            "reset_zoom_to_default",
+            "quick_inspect",
+            "open_session_order_viewer",
+            "toggle_zoom_reset_mode",
+            "open_shortcut_map",
+        ]
+        for name in callback_names:
+            setattr(dummy, name, lambda: None)
+
+        SessionDisplay.init_shortcuts(dummy)
+
+        self.assertEqual(dummy.grayscale_shortcut.key().toString(), "G")
+        self.assertEqual(dummy.flip_horizontal_shortcut.key().toString(), "H")
+        self.assertEqual(dummy.flip_vertical_shortcut.key().toString(), "V")
+        self.assertEqual(dummy.frameless_fullscreen.key().toString(), "Ctrl+Shift+F")
+        self.assertEqual(dummy.selection_order_key.key().toString(), "Ctrl+Shift+I")


### PR DESCRIPTION
## Summary

Adds a Selection Order Viewer accessible from the main window and session window via `Ctrl+Shift+I`. The viewer lets users inspect selected images with thumbnails, order numbers, status markers, selection stats, filtering, preview details, add/remove tools, duplicate/missing cleanup, sorting, shuffling, and manual reordering.

## Key Changes

- Added shared selection-order helpers for effective ordering, randomization previews, break insertion, duplicate detection, stats, and remaining-session validation.
- Updated session startup so randomization and break insertion operate on copied playlists instead of mutating `selection["files"]`.
- Added main-window order management:
  - `Manage Order` button
  - `Ctrl+Shift+I` shortcut
  - randomized preview that can be applied as a locked explicit order
- Added session-window order management:
  - `Order` button
  - `Ctrl+Shift+I` shortcut map entry
  - live edits for upcoming images only
  - locked already-shown/current rows and break markers
- Improved viewer responsiveness by loading only visible thumbnails plus a scroll buffer, using scaled image reads.
- Split large test coverage into focused test modules.
- Updated README, changelog, and tests README.

