### PR TITLE
docs: add release-merge PR template for v0.5.4

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-merge.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-merge.md
@@ -1,0 +1,12 @@
+## Release merge
+
+This PR merges `release/v0.5.4` into `main`.
+
+### Validation checklist
+- [ ] Confirm `CHANGELOG.md` includes `v0.5.4 - 2026-04-24`.
+- [ ] Confirm `src/gesturesesh/__init__.py` is set to `0.5.4`.
+- [ ] Confirm `README.md` references the latest release artifacts.
+- [ ] Verify CI passes on merge commit.
+
+### Notes
+- This merge is intended to back-merge release changes into `main` with no additional feature scope.


### PR DESCRIPTION
### Motivation
- Provide a dedicated PR template for merging `release/v0.5.4` into `main` so maintainers have a concise validation checklist and to reduce the chance of introducing unintended feature changes.

### Description
- Add `.github/PULL_REQUEST_TEMPLATE/release-merge.md` with instructions and a validation checklist to confirm `CHANGELOG.md` includes `v0.5.4 - 2026-04-24`, `src/gesturesesh/__init__.py` version, `README.md` release references, and that CI passes before merge.

### Testing
- Ran repository verification commands (`git status`, `git diff` for the new file) and committed the template successfully; no CI or unit tests were executed for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee4cbbf9b88330bae6310ba6ac87cd)