### PR TITLE
Hot fix/ F1 toggle fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Manage Order / Selection Order Viewer previews now render `.avif` and `.jxl` files. When Qt lacks a plugin for the format, the preview falls back to decoding via Pillow.
 - Closing the Shortcut Map or Manage Order dialogs now destroys them instead of leaving hidden window instances parented to the session, which had been accumulating in the Windows taskbar thumbnail preview.
 
+*hotfix*
+- **`open_shortcut_map`** now connects `dlg.finished` to a small handler that clears `self._shortcut_map_dialog`. The `WA_DeleteOnClose` change in #38 destroyed the C++ widget on close but left the Python wrapper cached, so the next F1 press called `isVisible()` on a deleted wrapper, raised `RuntimeError`, and silently fell through to the blocking modal `run_shortcut_map_dialog(...)` fallback. 
+
 ### Changed
 
 - Improved Shortcut Map readability with higher-contrast text and explicit row, header, and selection colors.

--- a/GestureSesh_macOS.spec
+++ b/GestureSesh_macOS.spec
@@ -53,6 +53,6 @@ app = BUNDLE(
     name='GestureSesh.app',
     icon='ui/resources/icons/brush.icns',
     bundle_identifier='com.gesturesesh.gesturesesh',
-    version='0.5.4',
+    version='0.5.5',
     codesign_identity=os.environ.get('CODESIGN_IDENTITY'),
 )

--- a/src/gesturesesh/main.py
+++ b/src/gesturesesh/main.py
@@ -29,7 +29,7 @@ from gesturesesh.utils.config import load_config
 from gesturesesh.utils.update_checker import UpdateChecker
 
 
-__version__ = "0.5.4"
+__version__ = "0.5.5"
 
 
 class MainApp(

--- a/src/gesturesesh/session_window.py
+++ b/src/gesturesesh/session_window.py
@@ -481,6 +481,11 @@ class SessionDisplay(
                 return
             dlg = ShortcutMapDialog(parent=self, shortcut_rows=self.shortcut_map_rows)
             dlg.setModal(False)
+            # Clear the cached reference when the dialog closes, otherwise the
+            # next toggle would call isVisible() on a wrapper whose C++ object
+            # was already destroyed by WA_DeleteOnClose, fall into the except
+            # branch, and open the blocking modal dialog instead.
+            dlg.finished.connect(self._clear_shortcut_map_dialog)
             dlg.show()
             dlg.raise_()
             self._shortcut_map_dialog = dlg
@@ -490,6 +495,9 @@ class SessionDisplay(
                 run_shortcut_map_dialog(parent=self, shortcut_rows=self.shortcut_map_rows)
             except Exception:
                 pass
+
+    def _clear_shortcut_map_dialog(self, *_args):
+        self._shortcut_map_dialog = None
 
     def _validate_session_order(self, files):
         required = remaining_required_images(


### PR DESCRIPTION
## Summary

Replaces the broken v0.5.5 tag. The originally shipped v0.5.5 binary had two
post-merge regressions from #38:

1. The F1 Shortcut Map toggle stopped working after the first close.
2. The binary self-reported its version as `0.5.4`, so the in-app updater
   would have prompted users to install v0.5.5 indefinitely.

This PR fixes both, after which the existing v0.5.5 release and tag are
deleted and re-cut on the merge commit.

## Changes

### Fixed
- **`open_shortcut_map`** now connects `dlg.finished` to a small handler
  that clears `self._shortcut_map_dialog`. The `WA_DeleteOnClose` change
  in #38 destroyed the C++ widget on close but left the Python wrapper
  cached, so the next F1 press called `isVisible()` on a deleted wrapper,
  raised `RuntimeError`, and silently fell through to the blocking modal
  `run_shortcut_map_dialog(...)` fallback. Caught by Codex review on #38.

### Chore
- Bump `__version__` in `src/gesturesesh/main.py` and `version` in
  `GestureSesh_macOS.spec` from `0.5.4` to `0.5.5`. The CHANGELOG heading
  `## v0.5.5 - 2026-05-25` already landed in #38.
