### PR TITLE
Fix EXIF orientation regression and skip hidden/AppleDouble files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to GestureSesh will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.5.6 - 2026-06-21
+
+### Fixed
+
+- Photos carrying an EXIF orientation tag (most phone and camera images) once again display upright during sessions. The image-loading refactor in v0.5.4 routed every format through `cv2.imdecode(..., IMREAD_UNCHANGED)`, which ignores EXIF orientation, so images that auto-rotated under v0.5.1's `IMREAD_COLOR` path began appearing rotated 90°. The orientation tag is now read and re-applied after decoding, preserving the alpha channel and bit depth.
+- macOS AppleDouble sidecar files (`._name.ext`) and other hidden dotfiles are no longer added to selections. They mirror a real image's extension but contain only metadata, so they were being queued and then failing to decode mid-session. They are now skipped silently when adding files or scanning folders.
+
 ## v0.5.5 - 2026-05-25
 
 ### Fixed

--- a/GestureSesh_macOS.spec
+++ b/GestureSesh_macOS.spec
@@ -53,6 +53,6 @@ app = BUNDLE(
     name='GestureSesh.app',
     icon='ui/resources/icons/brush.icns',
     bundle_identifier='com.gesturesesh.gesturesesh',
-    version='0.5.5',
+    version='0.5.6',
     codesign_identity=os.environ.get('CODESIGN_IDENTITY'),
 )

--- a/src/gesturesesh/__init__.py
+++ b/src/gesturesesh/__init__.py
@@ -4,7 +4,7 @@ GestureSesh - A drawing practice application for artists.
 This package contains the core functionality for the GestureSesh application.
 """
 
-__version__ = "0.5.4"
+__version__ = "0.5.6"
 __author__ = "adnv3k"
 __email__ = "ali@adnv3k.com"
 

--- a/src/gesturesesh/app/selection.py
+++ b/src/gesturesesh/app/selection.py
@@ -11,6 +11,7 @@ from gesturesesh.app.selection_order import (
     duplicate_indices,
     effective_selection_order,
 )
+from gesturesesh.session.constants import is_hidden_file
 from gesturesesh.ui.dialogs import run_selection_order_dialog
 
 
@@ -122,6 +123,11 @@ class MainAppSelectionMixin:
         """Checks if files are supported file types and are accessible."""
         res = {"valid_files": [], "invalid_files": []}
         for file in files:
+            # Hidden dotfiles and macOS AppleDouble sidecars (._name.ext) are OS
+            # noise, not user images; skip them silently so they are neither
+            # added nor counted as unsupported files.
+            if is_hidden_file(file):
+                continue
             ext = os.path.splitext(file)[1].lower()
             if ext not in self.valid_file_types:
                 res["invalid_files"].append(file)

--- a/src/gesturesesh/main.py
+++ b/src/gesturesesh/main.py
@@ -29,7 +29,7 @@ from gesturesesh.utils.config import load_config
 from gesturesesh.utils.update_checker import UpdateChecker
 
 
-__version__ = "0.5.5"
+__version__ = "0.5.6"
 
 
 class MainApp(

--- a/src/gesturesesh/session/constants.py
+++ b/src/gesturesesh/session/constants.py
@@ -5,6 +5,7 @@ Lives in its own module so submodules (timer, etc.) and the parent
 """
 
 import contextlib
+import os
 from importlib import resources
 from pathlib import Path
 
@@ -23,6 +24,20 @@ SUPPORTED_IMAGE_TYPES = {
 }
 
 SUPPORTED_ANIMATED_TYPES = {".avif", ".gif", ".jxl", ".webp"}
+
+
+def is_hidden_file(path) -> bool:
+    """Return True for hidden/sidecar files that should not be treated as images.
+
+    Matches any dotfile (basename starting with ``.``). The important case is the
+    macOS AppleDouble sidecar ``._name.ext``: it mirrors a real file's extension
+    (so an extension check alone accepts it) but holds resource-fork metadata
+    rather than image data. These are generated when files are copied to
+    FAT/exFAT/SMB/USB volumes and, if added to the playlist, fail to decode at
+    display time. Other dotfiles (``.DS_Store``, ``.thumbnails``, etc.) are OS
+    noise too, so we skip the whole class.
+    """
+    return os.path.basename(str(path)).startswith(".")
 
 
 def sound_file(name: str):

--- a/src/gesturesesh/session/image_loader.py
+++ b/src/gesturesesh/session/image_loader.py
@@ -295,9 +295,45 @@ class SessionImageLoaderMixin:
             else:
                 with open(image_path, "rb") as f:
                     file_bytes = np.asarray(bytearray(f.read()), dtype=np.uint8)
-            return cv2.imdecode(file_bytes, cv2.IMREAD_UNCHANGED)
+            cvimage = cv2.imdecode(file_bytes, cv2.IMREAD_UNCHANGED)
+            return self._apply_exif_orientation(cvimage, image_path)
         except Exception:
             return None
+
+    def _apply_exif_orientation(self, cvimage, image_path):
+        """Rotate/flip a cv2-decoded array to honor the source's EXIF orientation.
+
+        ``cv2.imdecode(..., IMREAD_UNCHANGED)`` deliberately ignores the EXIF
+        orientation tag (unlike ``IMREAD_COLOR``), so photos shot on phones and
+        cameras would display rotated. We read just the orientation tag via
+        Pillow (no pixel decode) and apply the matching transform, preserving the
+        alpha channel and bit depth that ``IMREAD_UNCHANGED`` gives us. The
+        transforms mirror ``PIL.ImageOps.exif_transpose`` so still images match
+        the Selection Order Viewer thumbnails.
+        """
+        if cvimage is None or Image is None or image_path.startswith(":/"):
+            return cvimage
+        try:
+            with Image.open(image_path) as pil_image:
+                orientation = int(pil_image.getexif().get(0x0112, 1) or 1)
+        except Exception:
+            return cvimage
+
+        if orientation == 2:  # mirror horizontal
+            return cv2.flip(cvimage, 1)
+        if orientation == 3:  # rotate 180
+            return cv2.rotate(cvimage, cv2.ROTATE_180)
+        if orientation == 4:  # mirror vertical
+            return cv2.flip(cvimage, 0)
+        if orientation == 5:  # mirror along the main diagonal (transpose)
+            return cv2.transpose(cvimage)
+        if orientation == 6:  # rotate 90 clockwise
+            return cv2.rotate(cvimage, cv2.ROTATE_90_CLOCKWISE)
+        if orientation == 7:  # mirror along the anti-diagonal (transverse)
+            return cv2.rotate(cv2.transpose(cvimage), cv2.ROTATE_180)
+        if orientation == 8:  # rotate 90 counterclockwise
+            return cv2.rotate(cvimage, cv2.ROTATE_90_COUNTERCLOCKWISE)
+        return cvimage
 
     def decode_with_pillow(self, image_path):
         if Image is None or image_path.startswith(":/"):

--- a/src/gesturesesh/ui/dialogs.py
+++ b/src/gesturesesh/ui/dialogs.py
@@ -24,6 +24,7 @@ from gesturesesh.app.selection_order import (
     duplicate_indices,
     selection_stats,
 )
+from gesturesesh.session.constants import is_hidden_file
 
 
 class OrderListWidget(QtWidgets.QListWidget):
@@ -543,6 +544,10 @@ class ImageManagerDialog(QtWidgets.QDialog):
     def _check_files(self, files):
         valid = []
         for file_path in files:
+            # Skip hidden dotfiles / macOS AppleDouble sidecars (._name.ext);
+            # they share a real image's extension but aren't decodable images.
+            if is_hidden_file(file_path):
+                continue
             ext = os.path.splitext(file_path)[1].lower()
             if self._valid_file_types and ext not in self._valid_file_types:
                 continue

--- a/tests/test_hidden_files.py
+++ b/tests/test_hidden_files.py
@@ -1,0 +1,82 @@
+"""Hidden dotfiles and macOS AppleDouble sidecars (``._name.ext``) must never be
+treated as images: they share a real file's extension but hold metadata, so they
+would be added to the playlist and then fail to decode at display time."""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src")
+)
+
+from gesturesesh.app.selection import MainAppSelectionMixin
+from gesturesesh.session.constants import is_hidden_file
+
+
+class TestIsHiddenFile(unittest.TestCase):
+    def test_appledouble_and_dotfiles_are_hidden(self):
+        for path in (
+            "/photos/._image1.jpg",
+            "._image1.jpg",
+            "/photos/.DS_Store",
+            "/photos/.hidden.png",
+        ):
+            self.assertTrue(is_hidden_file(path), path)
+
+    def test_normal_files_are_not_hidden(self):
+        for path in (
+            "/photos/image1.jpg",
+            "image1.jpg",
+            "/photos/my._weird.jpg",  # only a leading "._" basename counts
+            "/a.dotted.dir/image.png",
+        ):
+            self.assertFalse(is_hidden_file(path), path)
+
+
+class TestCheckFilesSkipsHidden(unittest.TestCase):
+    """Exercises the real ``MainAppSelectionMixin.check_files``."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        self.fake = types.SimpleNamespace(
+            valid_file_types={".jpg", ".jpeg", ".png", ".bmp"}
+        )
+
+    def _make(self, name):
+        path = os.path.join(self.tmp, name)
+        Path(path).touch()
+        return path
+
+    def test_appledouble_excluded_silently(self):
+        real = self._make("image1.jpg")
+        sidecar = self._make("._image1.jpg")
+        ds_store = self._make(".DS_Store")
+
+        result = MainAppSelectionMixin.check_files(
+            self.fake, [real, sidecar, ds_store]
+        )
+
+        self.assertEqual(result["valid_files"], [real])
+        # Hidden files are skipped silently, not reported as "unsupported".
+        self.assertEqual(result["invalid_files"], [])
+
+    def test_unsupported_extension_still_reported(self):
+        real = self._make("image1.jpg")
+        doc = self._make("notes.txt")
+
+        result = MainAppSelectionMixin.check_files(self.fake, [real, doc])
+
+        self.assertEqual(result["valid_files"], [real])
+        self.assertEqual(result["invalid_files"], [doc])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scan_directories.py
+++ b/tests/test_scan_directories.py
@@ -21,17 +21,24 @@ from pathlib import Path
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'src'))
 
 from gesturesesh.main import MainApp
+from gesturesesh.session.constants import is_hidden_file
 
 class TestableMainApp:
     """Lightweight testable version of MainApp for testing scan_directories"""
     def __init__(self):
         self.valid_file_types = {".bmp", ".jpg", ".jpeg", ".png"}
         self.selection = {"files": [], "folders": []}
-    
+
     def check_files(self, files):
-        """Checks if files are supported file types and are accessible."""
+        """Checks if files are supported file types and are accessible.
+
+        Mirrors ``MainAppSelectionMixin.check_files``: hidden dotfiles and macOS
+        AppleDouble sidecars (._name.ext) are skipped silently.
+        """
         res = {"valid_files": [], "invalid_files": []}
         for file in files:
+            if is_hidden_file(file):
+                continue
             ext = os.path.splitext(file)[1].lower()
             if ext not in self.valid_file_types:
                 res["invalid_files"].append(file)
@@ -216,6 +223,24 @@ class TestScanDirectories(unittest.TestCase):
         self.assertIsInstance(valid, int)
         self.assertIsInstance(invalid, int)
         
+    def test_appledouble_sidecars_are_skipped(self):
+        """macOS AppleDouble sidecars (._name.jpg) in a scanned folder must not
+        be added to the selection or counted as invalid."""
+        # These appear alongside real files on FAT/exFAT/SMB/USB volumes.
+        for name in ("._image1.jpg", "._sub_image1.jpeg", ".DS_Store"):
+            Path(os.path.join(self.test_dir, name)).touch()
+        Path(os.path.join(self.sub_dir, "._sub_image2.png")).touch()
+
+        self.app.selection = {"files": [], "folders": []}
+        valid, invalid = self.app.scan_directories([self.test_dir])
+
+        # Same totals as the clean tree: 5 valid, 2 invalid (txt + mp4).
+        self.assertEqual(valid, 5)
+        self.assertEqual(invalid, 2)
+        selected_basenames = [os.path.basename(f) for f in self.app.selection["files"]]
+        self.assertNotIn("._image1.jpg", selected_basenames)
+        self.assertFalse(any(name.startswith("._") for name in selected_basenames))
+
     def test_case_insensitive_extensions(self):
         """Test that file extensions are handled case-insensitively"""
         # Create files with uppercase extensions

--- a/tests/test_session_image_loader.py
+++ b/tests/test_session_image_loader.py
@@ -2,13 +2,16 @@ import os
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
+import io
 import sys
+import tempfile
 import types
 import unittest
 from collections import OrderedDict
 from unittest.mock import MagicMock
 
 import numpy as np
+from PIL import Image
 from PyQt5.QtWidgets import QApplication
 
 sys.path.insert(
@@ -101,3 +104,76 @@ class TestSessionImageLoaderMixin(unittest.TestCase):
         assert SessionImageLoaderMixin.normalize_cvimage_dtype(
             fake, float_image
         ).tolist() == [[0, 255]]
+
+
+class TestExifOrientation(unittest.TestCase):
+    """``IMREAD_UNCHANGED`` ignores EXIF orientation, so decode_with_cv2 must
+    re-apply it (regression from the 0.5.x image-loading refactor)."""
+
+    @staticmethod
+    def _decoder_fake():
+        fake = types.SimpleNamespace()
+        fake._apply_exif_orientation = (
+            lambda cvimage, path: SessionImageLoaderMixin._apply_exif_orientation(
+                fake, cvimage, path
+            )
+        )
+        return fake
+
+    @staticmethod
+    def _write_jpeg(path, height, width, orientation):
+        # A distinctive bright patch in the top-left so we can confirm not just
+        # the shape swap but the rotation direction.
+        arr = np.full((height, width, 3), 30, dtype=np.uint8)
+        arr[0 : height // 2, 0 : width // 2] = (255, 0, 0)
+        image = Image.fromarray(arr)
+        exif = image.getexif()
+        exif[0x0112] = orientation
+        image.save(path, format="JPEG", quality=95, exif=exif)
+
+    def test_decode_with_cv2_rotates_per_orientation_tag(self):
+        fake = self._decoder_fake()
+        with tempfile.TemporaryDirectory() as tmp:
+            # Stored pixels are landscape 20x40 (H x W).
+            for orientation, expect_swap in ((1, False), (6, True), (8, True)):
+                path = os.path.join(tmp, f"o{orientation}.jpg")
+                self._write_jpeg(path, height=20, width=40, orientation=orientation)
+                out = SessionImageLoaderMixin.decode_with_cv2(fake, path)
+                self.assertIsNotNone(out)
+                h, w = out.shape[:2]
+                if expect_swap:
+                    self.assertEqual((h, w), (40, 20), f"orientation {orientation}")
+                else:
+                    self.assertEqual((h, w), (20, 40), f"orientation {orientation}")
+
+    def test_orientation_6_and_8_rotate_opposite_directions(self):
+        fake = self._decoder_fake()
+        with tempfile.TemporaryDirectory() as tmp:
+            p6 = os.path.join(tmp, "o6.jpg")
+            p8 = os.path.join(tmp, "o8.jpg")
+            self._write_jpeg(p6, height=20, width=40, orientation=6)
+            self._write_jpeg(p8, height=20, width=40, orientation=8)
+            out6 = SessionImageLoaderMixin.decode_with_cv2(fake, p6)
+            out8 = SessionImageLoaderMixin.decode_with_cv2(fake, p8)
+            # Both become portrait but the red patch lands in opposite corners:
+            # orientation 6 (90 CW) -> top-right; orientation 8 (90 CCW) -> bottom-left.
+            def is_red(px):
+                b, g, r = int(px[0]), int(px[1]), int(px[2])
+                return r > 150 and g < 80 and b < 80
+            self.assertTrue(is_red(out6[2, -2]))   # top-right
+            self.assertTrue(is_red(out8[-3, 1]))   # bottom-left
+
+    def test_apply_exif_orientation_is_a_noop_without_metadata(self):
+        fake = self._decoder_fake()
+        cvimage = np.zeros((4, 6, 3), dtype=np.uint8)
+        # Resource paths (the break image) and missing Pillow metadata are left
+        # untouched rather than raising.
+        self.assertIs(
+            SessionImageLoaderMixin._apply_exif_orientation(
+                fake, cvimage, ":/break/break.png"
+            ),
+            cvimage,
+        )
+        self.assertIsNone(
+            SessionImageLoaderMixin._apply_exif_orientation(fake, None, "missing.jpg")
+        )


### PR DESCRIPTION
## Summary

Fixes two image-loading bugs reported after upgrading from v0.5.1 to v0.5.5, and
bumps the release to **v0.5.6**.

- **Images displayed rotated 90°** — EXIF orientation is no longer applied.
- **`._*` files fail to load** — macOS AppleDouble sidecars get queued and then
  fail to decode mid-session.

## Fix 1 — EXIF orientation regression

**Root cause.** v0.5.1 decoded JPEGs via `cv2.imdecode(ba, 1)` (`IMREAD_COLOR`),
which auto-applies the EXIF orientation tag. The image-loading refactor in v0.5.4
routed *every* format through `decode_with_cv2` using `cv2.imdecode(..., IMREAD_UNCHANGED)`,
which **ignores EXIF orientation**. The Pillow decoder that *does* honor orientation
(`ImageOps.exif_transpose`) only runs as a fallback when cv2 fails — and cv2 never
fails on a valid JPEG, so it was never reached. As a result, every photo carrying
an orientation tag (most phone/camera shots) displayed rotated. Notably, the
Selection Order Viewer thumbnails already use `exif_transpose`, so thumbnails
looked correct while the session view did not.

Verified empirically (OpenCV 4.12.0): a tagged JPEG decodes unrotated under
`IMREAD_UNCHANGED` but correctly rotated under `IMREAD_COLOR`.

**Fix.** Added `_apply_exif_orientation()`, invoked at the end of `decode_with_cv2`.
It reads only the orientation tag via Pillow (no pixel decode) and applies the
matching transform, keeping the alpha channel and bit depth that `IMREAD_UNCHANGED`
provides. All 8 orientation cases were verified pixel-identical to
`PIL.ImageOps.exif_transpose` (and produce contiguous arrays), so the session
display now matches the thumbnails. Resource paths (`:/`) and the missing-Pillow
case are guarded.

## Fix 2 — Hidden / AppleDouble files

**Root cause.** Files like `._photo.jpg` are macOS AppleDouble sidecars (created on
FAT/exFAT/SMB/USB volumes). They carry the real file's extension but contain only
metadata, so the extension-only file checks accepted them, added them to the
playlist, and they then failed to decode at display time.

**Fix.** Added a shared `is_hidden_file()` predicate (covers AppleDouble sidecars
and hidden dotfiles generally) and applied it in both file-intake paths
(`check_files` and the Image Manager dialog's `_check_files`). Such files are now
skipped **silently** — neither added nor counted as "unsupported", since they're
OS noise the user never sees.
