### PR TITLE
Associate image sets with saved presets (phase 1, under-the-hood)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version number (e.g., v0.5.4)'
+        description: 'Version number (e.g., v0.5.6)'
         required: true
-        default: 'v0.5.4'
+        default: 'v0.5.6'
 
 permissions:
   contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to GestureSesh will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.5.6 - 2026-06-21
+
+### Fixed
+
+- Photos carrying an EXIF orientation tag (most phone and camera images) once again display upright during sessions. The image-loading refactor in v0.5.4 routed every format through `cv2.imdecode(..., IMREAD_UNCHANGED)`, which ignores EXIF orientation, so images that auto-rotated under v0.5.1's `IMREAD_COLOR` path began appearing rotated 90°. The orientation tag is now read and re-applied after decoding, preserving the alpha channel and bit depth.
+- macOS AppleDouble sidecar files (`._name.ext`) and other hidden dotfiles are no longer added to selections. They mirror a real image's extension but contain only metadata, so they were being queued and then failing to decode mid-session. They are now skipped silently when adding files or scanning folders.
+
 ## v0.5.5 - 2026-05-25
 
 ### Fixed

--- a/GestureSesh_macOS.spec
+++ b/GestureSesh_macOS.spec
@@ -53,6 +53,6 @@ app = BUNDLE(
     name='GestureSesh.app',
     icon='ui/resources/icons/brush.icns',
     bundle_identifier='com.gesturesesh.gesturesesh',
-    version='0.5.5',
+    version='0.5.6',
     codesign_identity=os.environ.get('CODESIGN_IDENTITY'),
 )

--- a/src/gesturesesh/__init__.py
+++ b/src/gesturesesh/__init__.py
@@ -4,7 +4,7 @@ GestureSesh - A drawing practice application for artists.
 This package contains the core functionality for the GestureSesh application.
 """
 
-__version__ = "0.5.4"
+__version__ = "0.5.6"
 __author__ = "adnv3k"
 __email__ = "ali@adnv3k.com"
 

--- a/src/gesturesesh/app/presets.py
+++ b/src/gesturesesh/app/presets.py
@@ -24,30 +24,57 @@ class MainAppPresetsMixin:
         # with stale in-memory picks from the current app run.
         self.selection["files"] = []
         self.selection["folders"] = []
-
-        folders = recent.get("folders", [])
-        files = recent.get("files", [])
         loaded_any = False
-        if folders:
-            self.selection["folders"] = folders
-            self.scan_directories(folders)
-            loaded_any = True
-        if files:
-            checked = self.check_files(files)
-            self.selection["files"].extend(
-                file for file in checked["valid_files"] if file != BREAK_IMAGE_PATH
-            )
-            loaded_any = loaded_any or bool(checked["valid_files"])
 
-        # Preserve order while dropping accidental duplicates.
-        self.selection["files"] = list(dict.fromkeys(self.selection["files"]))
+        # Restore the recent preset first (guarded so programmatic combo changes
+        # don't trigger selection-set writes), then resolve which set the
+        # selection should come from.
+        self._loading = True
+        try:
+            if "recent_preset" in recent:
+                self.preset_loader_box.setCurrentIndex(recent.get("recent_preset", 0))
+                loaded_any = True
+            if "randomized" in recent:
+                self.randomize_selection.setChecked(recent.get("randomized", False))
+                loaded_any = True
+            name = self.preset_loader_box.currentText()
+            self._active_set_preset = name if name in self.presets else None
+        finally:
+            self._loading = False
 
-        if "recent_preset" in recent:
-            self.preset_loader_box.setCurrentIndex(recent.get("recent_preset", 0))
+        # The linked image set wins as the source of truth for the selection.
+        preset = (
+            self.presets.get(self._active_set_preset)
+            if self._active_set_preset
+            else None
+        )
+        set_id = preset.get("selection_id") if isinstance(preset, dict) else None
+
+        if set_id and set_id in self.selection_sets:
+            self.apply_selection_set(set_id)
             loaded_any = True
-        if "randomized" in recent:
-            self.randomize_selection.setChecked(recent.get("randomized", False))
-            loaded_any = True
+        else:
+            # No linked set: fall back to the recent file/folder list, then
+            # migrate it into a set for the active preset (one-time upgrade for
+            # pre-existing configs).
+            folders = recent.get("folders", [])
+            files = recent.get("files", [])
+            if folders:
+                self.selection["folders"] = folders
+                self.scan_directories(folders)
+                loaded_any = True
+            if files:
+                checked = self.check_files(files)
+                self.selection["files"].extend(
+                    file
+                    for file in checked["valid_files"]
+                    if file != BREAK_IMAGE_PATH
+                )
+                loaded_any = loaded_any or bool(checked["valid_files"])
+            # Preserve order while dropping accidental duplicates.
+            self.selection["files"] = list(dict.fromkeys(self.selection["files"]))
+            if self._active_set_preset:
+                self.write_back_active_set()
 
         self.remove_breaks()
         self.display_status()
@@ -239,11 +266,22 @@ class MainAppPresetsMixin:
             self.presets[preset_name] = {"schedule": schedule}
         self.config["presets"] = self.presets
         if preset_name not in self.preset_names:
-            self.update_presets()
-            self.preset_loader_box.setCurrentIndex(self.preset_loader_box.count() - 1)
+            self._loading = True
+            try:
+                self.update_presets()
+                self.preset_loader_box.setCurrentIndex(
+                    self.preset_loader_box.count() - 1
+                )
+            finally:
+                self._loading = False
         if wait_status:
             self.show_temporary_status(f"{preset_name} saved!", 3000)
         save_config(self.config_path, self.config)
+        # Associate the live selection with the saved preset: new presets adopt
+        # the current selection; re-saves refresh the link (copy-on-write if the
+        # set is shared). No-op when the selection matches the existing set.
+        self._active_set_preset = preset_name
+        self.write_back_active_set()
 
     def delete(self):
         preset_name = self.preset_loader_box.currentText()
@@ -253,9 +291,19 @@ class MainAppPresetsMixin:
         if preset_name in self.presets:
             del self.presets[preset_name]
             self.config["presets"] = self.presets
+            # Cull any image set the deleted preset was the last to reference.
+            self._gc_selection_sets()
+            self.config["selection_sets"] = self.selection_sets
             save_config(self.config_path, self.config)
         self.show_temporary_status(f"{preset_name} deleted!", 2000)
-        self.preset_loader_box.removeItem(self.preset_loader_box.currentIndex())
+        self._loading = True
+        try:
+            self.preset_loader_box.removeItem(self.preset_loader_box.currentIndex())
+        finally:
+            self._loading = False
+        if self._active_set_preset == preset_name:
+            current = self.preset_loader_box.currentText()
+            self._active_set_preset = current if current in self.presets else None
 
     def load(self):
         preset_name = self.preset_loader_box.currentText()

--- a/src/gesturesesh/app/selection.py
+++ b/src/gesturesesh/app/selection.py
@@ -11,6 +11,7 @@ from gesturesesh.app.selection_order import (
     duplicate_indices,
     effective_selection_order,
 )
+from gesturesesh.session.constants import is_hidden_file
 from gesturesesh.ui.dialogs import run_selection_order_dialog
 
 
@@ -122,6 +123,11 @@ class MainAppSelectionMixin:
         """Checks if files are supported file types and are accessible."""
         res = {"valid_files": [], "invalid_files": []}
         for file in files:
+            # Hidden dotfiles and macOS AppleDouble sidecars (._name.ext) are OS
+            # noise, not user images; skip them silently so they are neither
+            # added nor counted as unsupported files.
+            if is_hidden_file(file):
+                continue
             ext = os.path.splitext(file)[1].lower()
             if ext not in self.valid_file_types:
                 res["invalid_files"].append(file)

--- a/src/gesturesesh/app/selection_sets.py
+++ b/src/gesturesesh/app/selection_sets.py
@@ -1,0 +1,257 @@
+"""Per-preset image-set associations (phase 1: under-the-hood, no UI).
+
+An *image set* is a named-by-id snapshot of the selection (``files`` + ``folders``)
+that a preset can be linked to. The data model is normalized: presets hold a
+``selection_id`` reference and the sets themselves live once in
+``config["selection_sets"]`` keyed by a stable id, so multiple presets can share
+one set without duplicating the file list.
+
+Lifecycle rules (agreed design):
+
+* **Read on switch-in** – when the user deliberately switches to a preset, its
+  linked set is applied to the live selection (lazy validation + status report).
+* **Write on boundaries** – the live selection is written back to the active
+  preset's set only at clean boundaries (switching away, session start, app
+  close, explicit save), never on every edit. Reads and writes are kept on
+  separate triggers to avoid signal re-entrancy.
+* **Copy-on-write** – editing the selection for a preset whose set is shared by
+  another preset forks a new set for the current preset rather than mutating the
+  shared one.
+* **Garbage collection** – sets no longer referenced by any preset are culled
+  (which is also why a still-linked set can never be dropped).
+* **Offline safety** – when a set is applied while files are unavailable (e.g. an
+  unplugged external drive), only the available files load, but the write-back
+  preserves the unavailable ones instead of pruning them, so reconnecting the
+  drive brings the set back intact. Reconnect recovery: switch to another preset
+  and back to re-apply.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+from gesturesesh.utils.config import save_config
+
+
+class MainAppSelectionSetsMixin:
+    """Image-set association behavior mixed into ``MainApp``."""
+
+    def init_selection_sets(self):
+        """Initialize the in-memory store from config. Call after ``init_preset``."""
+        sets = self.config.get("selection_sets", {})
+        if not isinstance(sets, dict):
+            sets = {}
+        self.selection_sets = sets
+        self.config["selection_sets"] = self.selection_sets
+        # Name of the preset whose set the live selection currently represents.
+        # ``None`` means there is no real preset to write back to (e.g. the
+        # "Default" placeholder or an unsaved typed name).
+        self._active_set_preset = None
+
+    # -- helpers ---------------------------------------------------------------
+
+    def _new_set_id(self) -> str:
+        """Return a stable id not currently used by any set."""
+        while True:
+            set_id = uuid.uuid4().hex[:12]
+            if set_id not in self.selection_sets:
+                return set_id
+
+    def _selection_snapshot(self) -> dict:
+        """Snapshot the live selection (order preserved)."""
+        return {
+            "files": list(self.selection["files"]),
+            "folders": list(self.selection["folders"]),
+        }
+
+    def _set_refcount(self, set_id: str) -> int:
+        """How many presets reference *set_id*."""
+        return sum(
+            1
+            for preset in self.presets.values()
+            if isinstance(preset, dict) and preset.get("selection_id") == set_id
+        )
+
+    def _wrapped_preset(self, name: str) -> dict:
+        """Return *name*'s preset in wrapped form, upgrading legacy entries."""
+        preset = self.presets.get(name)
+        if not isinstance(preset, dict) or "schedule" not in preset:
+            preset = {"schedule": preset if isinstance(preset, dict) else {}}
+            self.presets[name] = preset
+        return preset
+
+    @staticmethod
+    def _is_offline(path: str) -> bool:
+        """True when *path*'s file is gone *and* its directory is too.
+
+        The heuristic distinguishes a disconnected drive / moved tree (the whole
+        directory is missing -> preserve) from an in-place deletion (the folder
+        still exists, the file was removed -> don't preserve). This keeps
+        external-drive workflows intact: unplugging a drive removes its mount
+        point, so every file under it reads as offline.
+        """
+        if os.path.isfile(path):
+            return False
+        parent = os.path.dirname(path) or os.sep
+        return not os.path.isdir(parent)
+
+    @staticmethod
+    def _is_offline_dir(path: str) -> bool:
+        """Folder variant of :meth:`_is_offline`."""
+        if os.path.isdir(path):
+            return False
+        parent = os.path.dirname(path.rstrip(os.sep)) or os.sep
+        return not os.path.isdir(parent)
+
+    def _merge_unavailable(self, snapshot: dict, stored: dict) -> dict:
+        """Reconcile the live selection with a stored set, preserving entries
+        that are absent only because their drive/tree is disconnected.
+
+        * No real edit (the live selection equals what the stored set currently
+          resolves to on disk) -> return the stored set verbatim, so a
+          disconnected drive never churns order or drops files.
+        * Real edit -> honor the user's order/edits for the visible items, then
+          re-append still-offline entries so they survive.
+        """
+        working_files = list(snapshot["files"])
+        working_folders = list(snapshot["folders"])
+        stored_files = list(stored.get("files", []))
+        stored_folders = list(stored.get("folders", []))
+
+        loadable_files = [f for f in stored_files if os.path.isfile(f)]
+        loadable_folders = [d for d in stored_folders if os.path.isdir(d)]
+
+        if working_files == loadable_files and working_folders == loadable_folders:
+            return {"files": stored_files, "folders": stored_folders}
+
+        working_fset = set(working_files)
+        reserved_files = [
+            f
+            for f in stored_files
+            if f not in working_fset and self._is_offline(f)
+        ]
+        working_dset = set(working_folders)
+        reserved_folders = [
+            d
+            for d in stored_folders
+            if d not in working_dset and self._is_offline_dir(d)
+        ]
+        return {
+            "files": working_files + reserved_files,
+            "folders": working_folders + reserved_folders,
+        }
+
+    def _gc_selection_sets(self) -> None:
+        """Remove sets not referenced by any preset (orphans only)."""
+        referenced = {
+            preset.get("selection_id")
+            for preset in self.presets.values()
+            if isinstance(preset, dict) and preset.get("selection_id")
+        }
+        for set_id in list(self.selection_sets.keys()):
+            if set_id not in referenced:
+                del self.selection_sets[set_id]
+
+    # -- read / write ----------------------------------------------------------
+
+    def apply_selection_set(self, set_id: str) -> None:
+        """Switch-in read: load *set_id* into the live selection.
+
+        Lazy validation: paths are applied as-is, then the ones that no longer
+        exist are dropped from the working selection and reported. A missing set
+        id is a no-op so the current selection is left untouched.
+        """
+        data = self.selection_sets.get(set_id)
+        if not data:
+            return
+        stored_files = list(data.get("files", []))
+        stored_folders = list(data.get("folders", []))
+
+        valid_files = self.check_files(stored_files)["valid_files"]
+        valid_folders = [f for f in stored_folders if os.path.isdir(f)]
+
+        self.selection["files"] = valid_files
+        self.selection["folders"] = valid_folders
+
+        missing = len(stored_files) - len(valid_files)
+        if missing > 0:
+            self.show_temporary_status(
+                f"Loaded {len(valid_files)} of {len(stored_files)} images "
+                f"— {missing} currently unavailable (kept in this preset).",
+                4000,
+            )
+        self.display_status()
+
+    def write_back_active_set(self) -> None:
+        """Boundary write: persist the live selection to the active preset's set.
+
+        Applies copy-on-write when the current set is shared, creates a set on
+        first write, GCs orphans, and persists. A no-op when there is no real
+        active preset or when nothing changed.
+        """
+        if getattr(self, "_loading", False):
+            return
+        name = self._active_set_preset
+        if not name or name not in self.presets:
+            return
+
+        snapshot = self._selection_snapshot()
+        preset = self._wrapped_preset(name)
+        existing_id = preset.get("selection_id")
+
+        if existing_id and existing_id in self.selection_sets:
+            stored = self.selection_sets[existing_id]
+            # Preserve entries missing only because their drive/tree is
+            # disconnected; never let an offline drive prune the stored set.
+            merged = self._merge_unavailable(snapshot, stored)
+            if merged == stored:
+                return  # no real change
+            if self._set_refcount(existing_id) > 1:
+                # shared + changed -> fork a new set for this preset
+                new_id = self._new_set_id()
+                self.selection_sets[new_id] = merged
+                preset["selection_id"] = new_id
+            else:
+                self.selection_sets[existing_id] = merged
+        else:
+            # No link yet: only worth remembering if there is something to store.
+            if not snapshot["files"] and not snapshot["folders"]:
+                return
+            new_id = self._new_set_id()
+            self.selection_sets[new_id] = snapshot
+            preset["selection_id"] = new_id
+
+        self.config["presets"] = self.presets
+        self._gc_selection_sets()
+        self.config["selection_sets"] = self.selection_sets
+        save_config(self.config_path, self.config)
+
+    # -- switch handler --------------------------------------------------------
+
+    def on_preset_switch(self, *args) -> None:
+        """Deliberate user preset switch: write back the old set, apply the new.
+
+        Wired to ``QComboBox.activated`` so it fires only on real user selection,
+        not on programmatic index changes or text editing.
+        """
+        if getattr(self, "_loading", False):
+            return
+        new_name = self.preset_loader_box.currentText()
+        if new_name == self._active_set_preset:
+            return
+
+        # Boundary write for the preset we are leaving (still the live selection).
+        self.write_back_active_set()
+
+        # Read for the preset we are entering.
+        self._active_set_preset = new_name if new_name in self.presets else None
+        if self._active_set_preset:
+            preset = self.presets.get(new_name)
+            set_id = (
+                preset.get("selection_id") if isinstance(preset, dict) else None
+            )
+            if set_id:
+                self.apply_selection_set(set_id)
+            # No linked set -> leave the current selection; it becomes this
+            # preset's set on the next boundary write.

--- a/src/gesturesesh/app/session.py
+++ b/src/gesturesesh/app/session.py
@@ -39,6 +39,8 @@ class MainAppSessionMixin:
 
         self.save(wait_status=False)
 
+        self.write_back_active_set()
+
         ordered_files = effective_selection_order(
             self.selection["files"], randomize=self.randomize_selection.isChecked()
         )

--- a/src/gesturesesh/main.py
+++ b/src/gesturesesh/main.py
@@ -20,20 +20,22 @@ if str(src_dir) not in sys.path:
 
 from gesturesesh.app.presets import MainAppPresetsMixin
 from gesturesesh.app.selection import MainAppSelectionMixin
+from gesturesesh.app.selection_sets import MainAppSelectionSetsMixin
 from gesturesesh.app.session import MainAppSessionMixin
 from gesturesesh.app.status import MainAppStatusMixin
 from gesturesesh.session.constants import SUPPORTED_IMAGE_TYPES
 from gesturesesh.ui.main_window import Ui_MainWindow
 from gesturesesh.utils import resources_config  # noqa: F401
-from gesturesesh.utils.config import load_config
+from gesturesesh.utils.config import get_config_dir, load_config
 from gesturesesh.utils.update_checker import UpdateChecker
 
 
-__version__ = "0.5.6"
+__version__ = "0.5.5"
 
 
 class MainApp(
     MainAppSelectionMixin,
+    MainAppSelectionSetsMixin,
     MainAppStatusMixin,
     MainAppPresetsMixin,
     MainAppSessionMixin,
@@ -45,10 +47,16 @@ class MainApp(
         self.setupUi(self)
         self.setWindowTitle("Reference Practice")
         self.config = load_config(self)
+        # Resolve the config path up front so saves don't depend on
+        # check_version() (which sets it later) having run first.
+        self.config_path = get_config_dir() / "config.json"
         self.session_schedule = []
         self.has_break = False
         self.valid_file_types = set(SUPPORTED_IMAGE_TYPES)
         self.selection = {"files": [], "folders": []}
+        # Re-entrancy guard for programmatic preset/selection changes so they
+        # don't trigger selection-set writes (see selection_sets.py).
+        self._loading = False
 
         self.status_timer = QtCore.QTimer()
         self.status_timer.setSingleShot(True)
@@ -69,6 +77,7 @@ class MainApp(
         self.init_buttons()
         self.init_shortcuts()
         self.init_preset()
+        self.init_selection_sets()
         self.load_recent()
         self.check_version()
         self.entry_table.itemChanged.connect(self.update_total)
@@ -78,6 +87,14 @@ class MainApp(
     def resizeEvent(self, event):
         super().resizeEvent(event)
         self.update_dynamic_fonts()
+
+    def closeEvent(self, event):
+        # Boundary write: persist the active preset's image set on app close.
+        try:
+            self.write_back_active_set()
+        except Exception:
+            pass
+        super().closeEvent(event)
 
     def update_dynamic_fonts(self):
         """Dynamically update font sizes based on window height."""
@@ -151,6 +168,11 @@ class MainApp(
         self.delete_preset.clicked.connect(self.delete)
         self.preset_loader_box.currentIndexChanged.connect(self.load)
         self.preset_loader_box.currentTextChanged.connect(self.load)
+        # Deliberate user preset switches drive selection-set read/write.
+        # `activated` fires only on real user selection, not programmatic
+        # index changes or typing, which keeps set logic off the re-entrant
+        # currentIndexChanged/currentTextChanged path.
+        self.preset_loader_box.activated.connect(self.on_preset_switch)
         # Buttons for table
         self.remove_entry.pressed.connect(self.remove_row)
         self.move_entry_up.clicked.connect(self.move_up)

--- a/src/gesturesesh/main.py
+++ b/src/gesturesesh/main.py
@@ -30,7 +30,7 @@ from gesturesesh.utils.config import get_config_dir, load_config
 from gesturesesh.utils.update_checker import UpdateChecker
 
 
-__version__ = "0.5.5"
+__version__ = "0.5.6"
 
 
 class MainApp(

--- a/src/gesturesesh/main.py
+++ b/src/gesturesesh/main.py
@@ -29,7 +29,7 @@ from gesturesesh.utils.config import load_config
 from gesturesesh.utils.update_checker import UpdateChecker
 
 
-__version__ = "0.5.5"
+__version__ = "0.5.6"
 
 
 class MainApp(

--- a/src/gesturesesh/session/constants.py
+++ b/src/gesturesesh/session/constants.py
@@ -5,6 +5,7 @@ Lives in its own module so submodules (timer, etc.) and the parent
 """
 
 import contextlib
+import os
 from importlib import resources
 from pathlib import Path
 
@@ -23,6 +24,20 @@ SUPPORTED_IMAGE_TYPES = {
 }
 
 SUPPORTED_ANIMATED_TYPES = {".avif", ".gif", ".jxl", ".webp"}
+
+
+def is_hidden_file(path) -> bool:
+    """Return True for hidden/sidecar files that should not be treated as images.
+
+    Matches any dotfile (basename starting with ``.``). The important case is the
+    macOS AppleDouble sidecar ``._name.ext``: it mirrors a real file's extension
+    (so an extension check alone accepts it) but holds resource-fork metadata
+    rather than image data. These are generated when files are copied to
+    FAT/exFAT/SMB/USB volumes and, if added to the playlist, fail to decode at
+    display time. Other dotfiles (``.DS_Store``, ``.thumbnails``, etc.) are OS
+    noise too, so we skip the whole class.
+    """
+    return os.path.basename(str(path)).startswith(".")
 
 
 def sound_file(name: str):

--- a/src/gesturesesh/session/image_loader.py
+++ b/src/gesturesesh/session/image_loader.py
@@ -295,9 +295,45 @@ class SessionImageLoaderMixin:
             else:
                 with open(image_path, "rb") as f:
                     file_bytes = np.asarray(bytearray(f.read()), dtype=np.uint8)
-            return cv2.imdecode(file_bytes, cv2.IMREAD_UNCHANGED)
+            cvimage = cv2.imdecode(file_bytes, cv2.IMREAD_UNCHANGED)
+            return self._apply_exif_orientation(cvimage, image_path)
         except Exception:
             return None
+
+    def _apply_exif_orientation(self, cvimage, image_path):
+        """Rotate/flip a cv2-decoded array to honor the source's EXIF orientation.
+
+        ``cv2.imdecode(..., IMREAD_UNCHANGED)`` deliberately ignores the EXIF
+        orientation tag (unlike ``IMREAD_COLOR``), so photos shot on phones and
+        cameras would display rotated. We read just the orientation tag via
+        Pillow (no pixel decode) and apply the matching transform, preserving the
+        alpha channel and bit depth that ``IMREAD_UNCHANGED`` gives us. The
+        transforms mirror ``PIL.ImageOps.exif_transpose`` so still images match
+        the Selection Order Viewer thumbnails.
+        """
+        if cvimage is None or Image is None or image_path.startswith(":/"):
+            return cvimage
+        try:
+            with Image.open(image_path) as pil_image:
+                orientation = int(pil_image.getexif().get(0x0112, 1) or 1)
+        except Exception:
+            return cvimage
+
+        if orientation == 2:  # mirror horizontal
+            return cv2.flip(cvimage, 1)
+        if orientation == 3:  # rotate 180
+            return cv2.rotate(cvimage, cv2.ROTATE_180)
+        if orientation == 4:  # mirror vertical
+            return cv2.flip(cvimage, 0)
+        if orientation == 5:  # mirror along the main diagonal (transpose)
+            return cv2.transpose(cvimage)
+        if orientation == 6:  # rotate 90 clockwise
+            return cv2.rotate(cvimage, cv2.ROTATE_90_CLOCKWISE)
+        if orientation == 7:  # mirror along the anti-diagonal (transverse)
+            return cv2.rotate(cv2.transpose(cvimage), cv2.ROTATE_180)
+        if orientation == 8:  # rotate 90 counterclockwise
+            return cv2.rotate(cvimage, cv2.ROTATE_90_COUNTERCLOCKWISE)
+        return cvimage
 
     def decode_with_pillow(self, image_path):
         if Image is None or image_path.startswith(":/"):

--- a/src/gesturesesh/ui/dialogs.py
+++ b/src/gesturesesh/ui/dialogs.py
@@ -24,6 +24,7 @@ from gesturesesh.app.selection_order import (
     duplicate_indices,
     selection_stats,
 )
+from gesturesesh.session.constants import is_hidden_file
 
 
 class OrderListWidget(QtWidgets.QListWidget):
@@ -543,6 +544,10 @@ class ImageManagerDialog(QtWidgets.QDialog):
     def _check_files(self, files):
         valid = []
         for file_path in files:
+            # Skip hidden dotfiles / macOS AppleDouble sidecars (._name.ext);
+            # they share a real image's extension but aren't decodable images.
+            if is_hidden_file(file_path):
+                continue
             ext = os.path.splitext(file_path)[1].lower()
             if self._valid_file_types and ext not in self._valid_file_types:
                 continue

--- a/tests/test_hidden_files.py
+++ b/tests/test_hidden_files.py
@@ -1,0 +1,82 @@
+"""Hidden dotfiles and macOS AppleDouble sidecars (``._name.ext``) must never be
+treated as images: they share a real file's extension but hold metadata, so they
+would be added to the playlist and then fail to decode at display time."""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src")
+)
+
+from gesturesesh.app.selection import MainAppSelectionMixin
+from gesturesesh.session.constants import is_hidden_file
+
+
+class TestIsHiddenFile(unittest.TestCase):
+    def test_appledouble_and_dotfiles_are_hidden(self):
+        for path in (
+            "/photos/._image1.jpg",
+            "._image1.jpg",
+            "/photos/.DS_Store",
+            "/photos/.hidden.png",
+        ):
+            self.assertTrue(is_hidden_file(path), path)
+
+    def test_normal_files_are_not_hidden(self):
+        for path in (
+            "/photos/image1.jpg",
+            "image1.jpg",
+            "/photos/my._weird.jpg",  # only a leading "._" basename counts
+            "/a.dotted.dir/image.png",
+        ):
+            self.assertFalse(is_hidden_file(path), path)
+
+
+class TestCheckFilesSkipsHidden(unittest.TestCase):
+    """Exercises the real ``MainAppSelectionMixin.check_files``."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        self.fake = types.SimpleNamespace(
+            valid_file_types={".jpg", ".jpeg", ".png", ".bmp"}
+        )
+
+    def _make(self, name):
+        path = os.path.join(self.tmp, name)
+        Path(path).touch()
+        return path
+
+    def test_appledouble_excluded_silently(self):
+        real = self._make("image1.jpg")
+        sidecar = self._make("._image1.jpg")
+        ds_store = self._make(".DS_Store")
+
+        result = MainAppSelectionMixin.check_files(
+            self.fake, [real, sidecar, ds_store]
+        )
+
+        self.assertEqual(result["valid_files"], [real])
+        # Hidden files are skipped silently, not reported as "unsupported".
+        self.assertEqual(result["invalid_files"], [])
+
+    def test_unsupported_extension_still_reported(self):
+        real = self._make("image1.jpg")
+        doc = self._make("notes.txt")
+
+        result = MainAppSelectionMixin.check_files(self.fake, [real, doc])
+
+        self.assertEqual(result["valid_files"], [real])
+        self.assertEqual(result["invalid_files"], [doc])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scan_directories.py
+++ b/tests/test_scan_directories.py
@@ -21,17 +21,24 @@ from pathlib import Path
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'src'))
 
 from gesturesesh.main import MainApp
+from gesturesesh.session.constants import is_hidden_file
 
 class TestableMainApp:
     """Lightweight testable version of MainApp for testing scan_directories"""
     def __init__(self):
         self.valid_file_types = {".bmp", ".jpg", ".jpeg", ".png"}
         self.selection = {"files": [], "folders": []}
-    
+
     def check_files(self, files):
-        """Checks if files are supported file types and are accessible."""
+        """Checks if files are supported file types and are accessible.
+
+        Mirrors ``MainAppSelectionMixin.check_files``: hidden dotfiles and macOS
+        AppleDouble sidecars (._name.ext) are skipped silently.
+        """
         res = {"valid_files": [], "invalid_files": []}
         for file in files:
+            if is_hidden_file(file):
+                continue
             ext = os.path.splitext(file)[1].lower()
             if ext not in self.valid_file_types:
                 res["invalid_files"].append(file)
@@ -216,6 +223,24 @@ class TestScanDirectories(unittest.TestCase):
         self.assertIsInstance(valid, int)
         self.assertIsInstance(invalid, int)
         
+    def test_appledouble_sidecars_are_skipped(self):
+        """macOS AppleDouble sidecars (._name.jpg) in a scanned folder must not
+        be added to the selection or counted as invalid."""
+        # These appear alongside real files on FAT/exFAT/SMB/USB volumes.
+        for name in ("._image1.jpg", "._sub_image1.jpeg", ".DS_Store"):
+            Path(os.path.join(self.test_dir, name)).touch()
+        Path(os.path.join(self.sub_dir, "._sub_image2.png")).touch()
+
+        self.app.selection = {"files": [], "folders": []}
+        valid, invalid = self.app.scan_directories([self.test_dir])
+
+        # Same totals as the clean tree: 5 valid, 2 invalid (txt + mp4).
+        self.assertEqual(valid, 5)
+        self.assertEqual(invalid, 2)
+        selected_basenames = [os.path.basename(f) for f in self.app.selection["files"]]
+        self.assertNotIn("._image1.jpg", selected_basenames)
+        self.assertFalse(any(name.startswith("._") for name in selected_basenames))
+
     def test_case_insensitive_extensions(self):
         """Test that file extensions are handled case-insensitively"""
         # Create files with uppercase extensions

--- a/tests/test_selection_sets.py
+++ b/tests/test_selection_sets.py
@@ -1,0 +1,293 @@
+"""Tests for per-preset image-set associations (selection_sets.py)."""
+
+import os
+import sys
+import types
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from PyQt5 import QtWidgets
+from PyQt5.QtWidgets import QApplication
+
+app = QApplication.instance()
+if app is None:
+    app = QApplication(sys.argv)
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
+
+from gesturesesh.main import MainApp
+from gesturesesh.ui.main_window import Ui_MainWindow
+
+
+def _mock_setup_ui(self, main_window):
+    """Minimal widget stubbing so MainApp() constructs without a real UI."""
+    self.selected_items = MagicMock(spec=QtWidgets.QTextEdit)
+    self.preset_loader_box = MagicMock(spec=QtWidgets.QComboBox)
+    self.entry_table = MagicMock(spec=QtWidgets.QTableWidget)
+    self.total_table = MagicMock(spec=QtWidgets.QTableWidget)
+    self.randomize_selection = MagicMock(spec=QtWidgets.QPushButton)
+    self.set_number_of_images = MagicMock(spec=QtWidgets.QSpinBox)
+    self.set_minutes = MagicMock(spec=QtWidgets.QSpinBox)
+    self.set_seconds = MagicMock(spec=QtWidgets.QSpinBox)
+    self.dialog_buttons = MagicMock(spec=QtWidgets.QDialogButtonBox)
+
+
+class TestSelectionSets(unittest.TestCase):
+    def setUp(self):
+        self._patchers = [
+            patch.object(Ui_MainWindow, "setupUi", _mock_setup_ui),
+            patch("gesturesesh.main.MainApp.check_version", lambda s: None),
+            patch("gesturesesh.main.MainApp.load_recent", lambda s: None),
+            patch("gesturesesh.main.MainApp.init_preset", lambda s: None),
+            patch("gesturesesh.main.MainApp.init_shortcuts", lambda s: None),
+            patch("gesturesesh.main.MainApp.init_buttons", lambda s: None),
+            patch("gesturesesh.main.MainApp.update_dynamic_fonts", lambda s: None),
+        ]
+        for p in self._patchers:
+            p.start()
+
+        self.test_dir = tempfile.mkdtemp()
+        self.app = MainApp()
+
+        # Isolate from the real on-disk config and any pre-existing state.
+        self.app.config = {}
+        self.app.config_path = Path(self.test_dir) / "config.json"
+        self.app.presets = {}
+        self.app.selection_sets = {}
+        self.app._active_set_preset = None
+        self.app._loading = False
+        self.app.selection = {"files": [], "folders": []}
+        # Keep status/UI side effects out of the logic under test.
+        self.app.show_temporary_status = types.MethodType(
+            lambda s, *a, **k: None, self.app
+        )
+        self.app.display_status = types.MethodType(lambda s: None, self.app)
+
+    def tearDown(self):
+        for p in self._patchers:
+            p.stop()
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def _touch(self, name):
+        path = os.path.join(self.test_dir, name)
+        with open(path, "w") as f:
+            f.write("x")
+        return path
+
+    # -- write-back / creation -------------------------------------------------
+
+    def test_first_write_creates_and_links_set(self):
+        self.app.presets = {"A": {"schedule": {}}}
+        self.app._active_set_preset = "A"
+        self.app.selection = {"files": ["/x.png"], "folders": ["/imgs"]}
+
+        self.app.write_back_active_set()
+
+        set_id = self.app.presets["A"].get("selection_id")
+        self.assertIsNotNone(set_id)
+        self.assertEqual(
+            self.app.selection_sets[set_id],
+            {"files": ["/x.png"], "folders": ["/imgs"]},
+        )
+
+    def test_empty_selection_creates_no_link(self):
+        self.app.presets = {"A": {"schedule": {}}}
+        self.app._active_set_preset = "A"
+        self.app.selection = {"files": [], "folders": []}
+
+        self.app.write_back_active_set()
+
+        self.assertNotIn("selection_id", self.app.presets["A"])
+        self.assertEqual(self.app.selection_sets, {})
+
+    def test_write_back_noop_when_unchanged(self):
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
+        self.app.selection_sets = {"set1": {"files": ["/x.png"], "folders": []}}
+        self.app._active_set_preset = "A"
+        self.app.selection = {"files": ["/x.png"], "folders": []}
+
+        self.app.write_back_active_set()
+
+        self.assertEqual(self.app.presets["A"]["selection_id"], "set1")
+        self.assertEqual(list(self.app.selection_sets.keys()), ["set1"])
+
+    def test_unshared_set_updated_in_place(self):
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
+        self.app.selection_sets = {"set1": {"files": ["/x.png"], "folders": []}}
+        self.app._active_set_preset = "A"
+        self.app.selection = {"files": ["/x.png", "/y.png"], "folders": []}
+
+        self.app.write_back_active_set()
+
+        self.assertEqual(self.app.presets["A"]["selection_id"], "set1")
+        self.assertEqual(
+            self.app.selection_sets["set1"],
+            {"files": ["/x.png", "/y.png"], "folders": []},
+        )
+
+    def test_shared_set_edit_forks_copy_on_write(self):
+        self.app.presets = {
+            "A": {"schedule": {}, "selection_id": "set1"},
+            "B": {"schedule": {}, "selection_id": "set1"},
+        }
+        self.app.selection_sets = {"set1": {"files": ["/x.png"], "folders": []}}
+        self.app._active_set_preset = "B"
+        self.app.selection = {"files": ["/x.png", "/y.png"], "folders": []}
+
+        self.app.write_back_active_set()
+
+        # A keeps the original set untouched; B gets a fresh forked set.
+        self.assertEqual(self.app.presets["A"]["selection_id"], "set1")
+        self.assertEqual(self.app.selection_sets["set1"], {"files": ["/x.png"], "folders": []})
+        new_id = self.app.presets["B"]["selection_id"]
+        self.assertNotEqual(new_id, "set1")
+        self.assertEqual(
+            self.app.selection_sets[new_id],
+            {"files": ["/x.png", "/y.png"], "folders": []},
+        )
+
+    def test_loading_guard_suppresses_write(self):
+        self.app.presets = {"A": {"schedule": {}}}
+        self.app._active_set_preset = "A"
+        self.app.selection = {"files": ["/x.png"], "folders": []}
+        self.app._loading = True
+
+        self.app.write_back_active_set()
+
+        self.assertNotIn("selection_id", self.app.presets["A"])
+        self.assertEqual(self.app.selection_sets, {})
+
+    # -- external-drive / offline safety --------------------------------------
+
+    def test_offline_set_preserved_when_no_edits(self):
+        # Paths under a directory that does not exist (simulates an unplugged
+        # drive: the whole mount point is gone).
+        offline = [
+            "/Volumes/NopeDriveXYZ/refs/a.png",
+            "/Volumes/NopeDriveXYZ/refs/b.png",
+        ]
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
+        self.app.selection_sets = {
+            "set1": {"files": list(offline), "folders": ["/Volumes/NopeDriveXYZ/refs"]}
+        }
+        self.app._active_set_preset = "A"
+        # apply() while offline would leave the working selection empty.
+        self.app.selection = {"files": [], "folders": []}
+
+        self.app.write_back_active_set()
+
+        self.assertEqual(self.app.selection_sets["set1"]["files"], offline)
+
+    def test_offline_files_preserved_when_adding_local_file(self):
+        offline = "/Volumes/NopeDriveXYZ/refs/a.png"
+        local = self._touch("local.png")
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
+        self.app.selection_sets = {"set1": {"files": [offline], "folders": []}}
+        self.app._active_set_preset = "A"
+        # User added a local file while the drive was disconnected.
+        self.app.selection = {"files": [local], "folders": []}
+
+        self.app.write_back_active_set()
+
+        files = self.app.selection_sets["set1"]["files"]
+        self.assertIn(local, files)
+        self.assertIn(offline, files)
+
+    def test_in_place_deleted_file_dropped_offline_kept(self):
+        # f1 exists then is removed by the user (its folder still exists ->
+        # treated as a real removal). offline file's tree is gone -> preserved.
+        f1 = self._touch("keep_then_remove.png")
+        offline = "/Volumes/NopeDriveXYZ/refs/b.png"
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
+        self.app.selection_sets = {"set1": {"files": [f1, offline], "folders": []}}
+        self.app._active_set_preset = "A"
+        # User removed f1 from the visible selection.
+        self.app.selection = {"files": [], "folders": []}
+
+        self.app.write_back_active_set()
+
+        self.assertEqual(self.app.selection_sets["set1"]["files"], [offline])
+
+    # -- garbage collection ----------------------------------------------------
+
+    def test_gc_removes_orphans_keeps_linked(self):
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
+        self.app.selection_sets = {
+            "set1": {"files": ["/x.png"], "folders": []},
+            "orphan": {"files": ["/z.png"], "folders": []},
+        }
+
+        self.app._gc_selection_sets()
+
+        self.assertIn("set1", self.app.selection_sets)
+        self.assertNotIn("orphan", self.app.selection_sets)
+
+    # -- apply / lazy validation ----------------------------------------------
+
+    def test_apply_set_drops_missing_files_preserves_order(self):
+        f1 = self._touch("a.png")
+        f2 = self._touch("b.png")
+        missing = os.path.join(self.test_dir, "gone.png")
+        self.app.selection_sets = {
+            "set1": {"files": [f1, missing, f2], "folders": [self.test_dir]}
+        }
+
+        self.app.apply_selection_set("set1")
+
+        self.assertEqual(self.app.selection["files"], [f1, f2])
+        self.assertEqual(self.app.selection["folders"], [self.test_dir])
+
+    def test_apply_missing_id_is_noop(self):
+        self.app.selection = {"files": ["/keep.png"], "folders": ["/keep"]}
+        self.app.apply_selection_set("does-not-exist")
+        self.assertEqual(self.app.selection, {"files": ["/keep.png"], "folders": ["/keep"]})
+
+    # -- switch handler --------------------------------------------------------
+
+    def test_on_preset_switch_writes_old_and_applies_new(self):
+        b1 = self._touch("b1.png")
+        self.app.presets = {
+            "A": {"schedule": {}, "selection_id": "setA"},
+            "B": {"schedule": {}, "selection_id": "setB"},
+        }
+        self.app.selection_sets = {
+            "setA": {"files": ["/old.png"], "folders": []},
+            "setB": {"files": [b1], "folders": []},
+        }
+        self.app._active_set_preset = "A"
+        # Live working copy for A diverged from setA.
+        self.app.selection = {"files": ["/a-new.png"], "folders": []}
+        self.app.preset_loader_box.currentText = lambda: "B"
+
+        self.app.on_preset_switch()
+
+        # A's set was written back from the live selection (unshared -> in place).
+        self.assertEqual(
+            self.app.selection_sets["setA"], {"files": ["/a-new.png"], "folders": []}
+        )
+        # B's set is applied to the live selection (validated).
+        self.assertEqual(self.app.selection["files"], [b1])
+        self.assertEqual(self.app._active_set_preset, "B")
+
+    def test_on_preset_switch_unlinked_target_keeps_selection(self):
+        self.app.presets = {
+            "A": {"schedule": {}, "selection_id": "setA"},
+            "B": {"schedule": {}},  # no linked set
+        }
+        self.app.selection_sets = {"setA": {"files": ["/old.png"], "folders": []}}
+        self.app._active_set_preset = "A"
+        self.app.selection = {"files": ["/keep.png"], "folders": []}
+        self.app.preset_loader_box.currentText = lambda: "B"
+
+        self.app.on_preset_switch()
+
+        # Switching to an unlinked preset leaves the current selection in place.
+        self.assertEqual(self.app.selection["files"], ["/keep.png"])
+        self.assertEqual(self.app._active_set_preset, "B")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_image_loader.py
+++ b/tests/test_session_image_loader.py
@@ -2,13 +2,16 @@ import os
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
+import io
 import sys
+import tempfile
 import types
 import unittest
 from collections import OrderedDict
 from unittest.mock import MagicMock
 
 import numpy as np
+from PIL import Image
 from PyQt5.QtWidgets import QApplication
 
 sys.path.insert(
@@ -101,3 +104,76 @@ class TestSessionImageLoaderMixin(unittest.TestCase):
         assert SessionImageLoaderMixin.normalize_cvimage_dtype(
             fake, float_image
         ).tolist() == [[0, 255]]
+
+
+class TestExifOrientation(unittest.TestCase):
+    """``IMREAD_UNCHANGED`` ignores EXIF orientation, so decode_with_cv2 must
+    re-apply it (regression from the 0.5.x image-loading refactor)."""
+
+    @staticmethod
+    def _decoder_fake():
+        fake = types.SimpleNamespace()
+        fake._apply_exif_orientation = (
+            lambda cvimage, path: SessionImageLoaderMixin._apply_exif_orientation(
+                fake, cvimage, path
+            )
+        )
+        return fake
+
+    @staticmethod
+    def _write_jpeg(path, height, width, orientation):
+        # A distinctive bright patch in the top-left so we can confirm not just
+        # the shape swap but the rotation direction.
+        arr = np.full((height, width, 3), 30, dtype=np.uint8)
+        arr[0 : height // 2, 0 : width // 2] = (255, 0, 0)
+        image = Image.fromarray(arr)
+        exif = image.getexif()
+        exif[0x0112] = orientation
+        image.save(path, format="JPEG", quality=95, exif=exif)
+
+    def test_decode_with_cv2_rotates_per_orientation_tag(self):
+        fake = self._decoder_fake()
+        with tempfile.TemporaryDirectory() as tmp:
+            # Stored pixels are landscape 20x40 (H x W).
+            for orientation, expect_swap in ((1, False), (6, True), (8, True)):
+                path = os.path.join(tmp, f"o{orientation}.jpg")
+                self._write_jpeg(path, height=20, width=40, orientation=orientation)
+                out = SessionImageLoaderMixin.decode_with_cv2(fake, path)
+                self.assertIsNotNone(out)
+                h, w = out.shape[:2]
+                if expect_swap:
+                    self.assertEqual((h, w), (40, 20), f"orientation {orientation}")
+                else:
+                    self.assertEqual((h, w), (20, 40), f"orientation {orientation}")
+
+    def test_orientation_6_and_8_rotate_opposite_directions(self):
+        fake = self._decoder_fake()
+        with tempfile.TemporaryDirectory() as tmp:
+            p6 = os.path.join(tmp, "o6.jpg")
+            p8 = os.path.join(tmp, "o8.jpg")
+            self._write_jpeg(p6, height=20, width=40, orientation=6)
+            self._write_jpeg(p8, height=20, width=40, orientation=8)
+            out6 = SessionImageLoaderMixin.decode_with_cv2(fake, p6)
+            out8 = SessionImageLoaderMixin.decode_with_cv2(fake, p8)
+            # Both become portrait but the red patch lands in opposite corners:
+            # orientation 6 (90 CW) -> top-right; orientation 8 (90 CCW) -> bottom-left.
+            def is_red(px):
+                b, g, r = int(px[0]), int(px[1]), int(px[2])
+                return r > 150 and g < 80 and b < 80
+            self.assertTrue(is_red(out6[2, -2]))   # top-right
+            self.assertTrue(is_red(out8[-3, 1]))   # bottom-left
+
+    def test_apply_exif_orientation_is_a_noop_without_metadata(self):
+        fake = self._decoder_fake()
+        cvimage = np.zeros((4, 6, 3), dtype=np.uint8)
+        # Resource paths (the break image) and missing Pillow metadata are left
+        # untouched rather than raising.
+        self.assertIs(
+            SessionImageLoaderMixin._apply_exif_orientation(
+                fake, cvimage, ":/break/break.png"
+            ),
+            cvimage,
+        )
+        self.assertIsNone(
+            SessionImageLoaderMixin._apply_exif_orientation(fake, None, "missing.jpg")
+        )


### PR DESCRIPTION
## Summary

Saved presets ("profiles") now remember the image set used with them. When you
switch to a preset, its last-used selection is restored; when you work under a
preset, that selection is associated with it. This is **phase 1: the data model
and behavior only — no new UI**.

Motivation: previously the image selection was a single global thing, unrelated
to presets. Swapping presets only swapped the schedule, so users re-picked their
images every time they changed profiles.

## Design

- **Normalized store.** Sets live once in `config["selection_sets"]` keyed by a
  stable id; presets hold an optional `selection_id`. Shared sets aren't
  duplicated.
- **Read on switch-in, write on boundaries.** Reads happen on a deliberate user
  preset switch (`QComboBox.activated`); writes happen only at clean boundaries
  (switch-away, session start, app close, explicit save) — never on every edit.
  Keeping reads and writes on separate triggers avoids signal re-entrancy, which
  is further guarded by a `_loading` flag.
- **Copy-on-write.** Editing a set shared by more than one preset forks a new set
  for the active preset instead of mutating the shared one.
- **Garbage collection.** Sets no longer referenced by any preset are culled
  (which is also why a still-linked set can never be dropped).
- **Linked set wins at startup.** `recent_session` only remembers *which* preset
  was active; that preset's set provides the images. Pre-existing configs migrate
  their recent selection into a set on first launch.
- **External-drive safety.** Applying a set while files are unavailable loads only
  what's present, but write-back preserves entries that are missing because their
  drive/tree is disconnected. An unplugged external drive never prunes a set;
  reconnect recovery is to switch preset away and back.

## Behavior

| Scenario | Result |
|---|---|
| Switch to a preset | Its linked image set is applied (missing files reported, kept) |
| Switch / start session / close / save | Live selection written back to the active preset (COW if shared) |
| New preset name + save | Adopts the current selection |
| Drive unplugged, switch in → out | Set fully preserved |
| Drive unplugged, add local files | Locals added, offline files kept |
| Remove a visible file | Removed normally; in-place deletions dropped |

## Testing

- New `tests/test_selection_sets.py` (14 tests): creation, no-op, in-place update,
  COW fork, GC, lazy validation, switch handler, `_loading` guard, and offline
  safety.
- Full suite: **73 passed, 2 pre-existing skips.**
- Logic-level only (UI mocked); a live run with a real external drive is the
  remaining manual confirmation.

## Deferred (phase 2)

A user-facing named-image-sets management section. The data model is identical,
so it's purely additive UI with no migration when there's demand.

## Known limitation

If a user deletes an entire folder that lives under a now-missing parent, those
entries read as "offline" and persist until phase-2 UI can prune them — erring
toward preservation.
