### PR TITLE
Reveal images in the file manager and surface unavailable preset files in Manage Order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Photos carrying an EXIF orientation tag (most phone and camera images) once again display upright during sessions. The image-loading refactor in v0.5.4 routed every format through `cv2.imdecode(..., IMREAD_UNCHANGED)`, which ignores EXIF orientation, so images that auto-rotated under v0.5.1's `IMREAD_COLOR` path began appearing rotated 90°. The orientation tag is now read and re-applied after decoding, preserving the alpha channel and bit depth.
 - macOS AppleDouble sidecar files (`._name.ext`) and other hidden dotfiles are no longer added to selections. They mirror a real image's extension but contain only metadata, so they were being queued and then failing to decode mid-session. They are now skipped silently when adding files or scanning folders.
 
+### Added
+- **Manage Order** can now reveal the highlighted image directly in your file
+  browser (Windows/macOS select the file; Linux opens its folder), and a new
+  **Show Missing** filter isolates files that are missing from disk.
+
+### Changed
+- Switching to a preset with missing/moved images now points you to Manage
+  Order, where the missing files are listed as removable **MISSING** rows
+  instead of just reporting a count. Removing them there sticks, while files on
+  a temporarily disconnected drive stay saved in the preset and return when the
+  drive is back.
+  
 ## v0.5.5 - 2026-05-25
 
 ### Fixed

--- a/src/gesturesesh/app/selection.py
+++ b/src/gesturesesh/app/selection.py
@@ -190,17 +190,14 @@ class MainAppSelectionMixin:
             self.session_schedule = []
 
         random_preview = bool(self.randomize_selection.isChecked())
-        files = effective_selection_order(
-            self.selection["files"], randomize=random_preview
-        )
         # Surface the active preset's saved-but-missing entries as MISSING rows
         # the user can see and act on (Remove Missing), instead of dropping them
-        # silently. De-dupe against what is already loaded.
-        seen_files = set(files)
-        files += [f for f in unavailable["files"] if f not in seen_files]
+        # silently. Reinsert them at their stored positions (not appended) so an
+        # unchanged Apply preserves saved order; randomize then shuffles all.
+        files = self._merge_missing_into_order(self.selection["files"])
+        files = effective_selection_order(files, randomize=random_preview)
         folders = list(self.selection["folders"])
-        seen_folders = set(folders)
-        folders += [d for d in unavailable["folders"] if d not in seen_folders]
+        folders += [d for d in unavailable["folders"] if d not in set(folders)]
 
         result = run_selection_order_dialog(
             parent=self,
@@ -227,7 +224,9 @@ class MainAppSelectionMixin:
             },
             authoritative=True,
         )
-        self.selection["files"] = [f for f in result["files"] if os.path.isfile(f)]
+        # Revalidate (not just isfile): drop unsupported or hidden paths such as
+        # AppleDouble sidecars so the next session never tries to decode them.
+        self.selection["files"] = self.check_files(result["files"])["valid_files"]
         self.selection["folders"] = [d for d in result["folders"] if os.path.isdir(d)]
         if result.get("random_preview"):
             self.randomize_selection.setChecked(False)

--- a/src/gesturesesh/app/selection.py
+++ b/src/gesturesesh/app/selection.py
@@ -177,7 +177,10 @@ class MainAppSelectionMixin:
 
     def open_selection_order_viewer(self):
         """Open the selection viewer/order editor from the main window."""
-        if not self.selection["files"]:
+        unavailable = self._active_set_unavailable()
+        if not self.selection["files"] and not (
+            unavailable["files"] or unavailable["folders"]
+        ):
             self.show_error_status("No images selected to manage.", 2500)
             return
 
@@ -190,21 +193,42 @@ class MainAppSelectionMixin:
         files = effective_selection_order(
             self.selection["files"], randomize=random_preview
         )
+        # Surface the active preset's saved-but-missing entries as MISSING rows
+        # the user can see and act on (Remove Missing), instead of dropping them
+        # silently. De-dupe against what is already loaded.
+        seen_files = set(files)
+        files += [f for f in unavailable["files"] if f not in seen_files]
+        folders = list(self.selection["folders"])
+        seen_folders = set(folders)
+        folders += [d for d in unavailable["folders"] if d not in seen_folders]
+
         result = run_selection_order_dialog(
             parent=self,
             files=files,
-            folders=self.selection["folders"],
+            folders=folders,
             schedule=self.session_schedule,
             valid_file_types=self.valid_file_types,
             duplicate_indices_fn=duplicate_indices,
             title="Selection Order",
             random_preview=random_preview,
+            focus_missing=bool(unavailable["files"] or unavailable["folders"]),
         )
         if result is None:
             return
 
-        self.selection["files"] = result["files"]
-        self.selection["folders"] = result["folders"]
+        # The viewer showed every entry (including missing ones), so its result
+        # is the authoritative set for this preset: persist it directly so that
+        # "Remove Missing" sticks even for offline-drive files. The live
+        # selection then keeps only what is currently loadable.
+        self.write_back_active_set(
+            snapshot={
+                "files": list(result["files"]),
+                "folders": list(result["folders"]),
+            },
+            authoritative=True,
+        )
+        self.selection["files"] = [f for f in result["files"] if os.path.isfile(f)]
+        self.selection["folders"] = [d for d in result["folders"] if os.path.isdir(d)]
         if result.get("random_preview"):
             self.randomize_selection.setChecked(False)
             self.show_temporary_status(

--- a/src/gesturesesh/app/selection_sets.py
+++ b/src/gesturesesh/app/selection_sets.py
@@ -203,6 +203,40 @@ class MainAppSelectionSetsMixin:
             "folders": [d for d in data.get("folders", []) if not os.path.isdir(d)],
         }
 
+    def _merge_missing_into_order(self, live_files):
+        """Return *live_files* with the active preset's stored-but-unavailable
+        entries reinserted at their stored positions.
+
+        The Manage Order viewer shows the full set and its result is written
+        back authoritatively, so appending missing items at the end would let an
+        unchanged Apply reorder the saved set (e.g. ``[missingA, presentB]`` ->
+        ``[presentB, missingA]``). Reinserting each unavailable entry just before
+        the next stored entry that is still loadable keeps the saved order stable
+        for a no-op round trip, while preserving live reordering and additions.
+        """
+        result = list(live_files)
+        name = getattr(self, "_active_set_preset", None)
+        preset = self.presets.get(name) if name else None
+        set_id = preset.get("selection_id") if isinstance(preset, dict) else None
+        data = self.selection_sets.get(set_id) if set_id else None
+        if not data:
+            return result
+        stored = list(data.get("files", []))
+        loadable = set(self.check_files(stored)["valid_files"])
+        live_set = set(live_files)
+        for index, path in enumerate(stored):
+            if path in loadable or path in result:
+                continue  # available (already live) or already placed
+            anchor = next(
+                (stored[j] for j in range(index + 1, len(stored)) if stored[j] in live_set),
+                None,
+            )
+            if anchor in result:
+                result.insert(result.index(anchor), path)
+            else:
+                result.append(path)
+        return result
+
     def write_back_active_set(self, snapshot=None, *, authoritative=False) -> None:
         """Boundary write: persist the live selection to the active preset's set.
 

--- a/src/gesturesesh/app/selection_sets.py
+++ b/src/gesturesesh/app/selection_sets.py
@@ -177,18 +177,44 @@ class MainAppSelectionSetsMixin:
         missing = len(stored_files) - len(valid_files)
         if missing > 0:
             self.show_temporary_status(
-                f"Loaded {len(valid_files)} of {len(stored_files)} images "
-                f"— {missing} currently unavailable (kept in this preset).",
-                4000,
+                f"Loaded {len(valid_files)} of {len(stored_files)} images — "
+                f"{missing} not found. Open Manage Order to review them.",
+                5000,
             )
         self.display_status()
 
-    def write_back_active_set(self) -> None:
+    def _active_set_unavailable(self) -> dict:
+        """Files/folders linked to the active preset that aren't on disk now.
+
+        Lets the Manage Order viewer tell the user *which* saved entries a
+        preset switch could not load (they stay saved in the preset). Returns
+        empty lists when there is no active preset or it has no linked set.
+        """
+        name = getattr(self, "_active_set_preset", None)
+        preset = self.presets.get(name) if name else None
+        set_id = preset.get("selection_id") if isinstance(preset, dict) else None
+        data = self.selection_sets.get(set_id) if set_id else None
+        if not data:
+            return {"files": [], "folders": []}
+        stored_files = list(data.get("files", []))
+        loadable = set(self.check_files(stored_files)["valid_files"])
+        return {
+            "files": [f for f in stored_files if f not in loadable],
+            "folders": [d for d in data.get("folders", []) if not os.path.isdir(d)],
+        }
+
+    def write_back_active_set(self, snapshot=None, *, authoritative=False) -> None:
         """Boundary write: persist the live selection to the active preset's set.
 
         Applies copy-on-write when the current set is shared, creates a set on
         first write, GCs orphans, and persists. A no-op when there is no real
         active preset or when nothing changed.
+
+        With an explicit *snapshot* the caller supplies the files/folders to
+        store instead of the live selection; *authoritative* then skips the
+        offline-preserving merge so the stored set becomes exactly *snapshot*.
+        Used after the user curates the full set (including missing entries) in
+        Manage Order, so a removal there actually sticks.
         """
         if getattr(self, "_loading", False):
             return
@@ -196,24 +222,30 @@ class MainAppSelectionSetsMixin:
         if not name or name not in self.presets:
             return
 
-        snapshot = self._selection_snapshot()
+        if snapshot is None:
+            snapshot = self._selection_snapshot()
         preset = self._wrapped_preset(name)
         existing_id = preset.get("selection_id")
 
         if existing_id and existing_id in self.selection_sets:
             stored = self.selection_sets[existing_id]
-            # Preserve entries missing only because their drive/tree is
-            # disconnected; never let an offline drive prune the stored set.
-            merged = self._merge_unavailable(snapshot, stored)
-            if merged == stored:
+            if authoritative:
+                # Caller curated the full set (e.g. via Manage Order); store it
+                # verbatim so removals are honored.
+                new_data = snapshot
+            else:
+                # Preserve entries missing only because their drive/tree is
+                # disconnected; never let an offline drive prune the stored set.
+                new_data = self._merge_unavailable(snapshot, stored)
+            if new_data == stored:
                 return  # no real change
             if self._set_refcount(existing_id) > 1:
                 # shared + changed -> fork a new set for this preset
                 new_id = self._new_set_id()
-                self.selection_sets[new_id] = merged
+                self.selection_sets[new_id] = new_data
                 preset["selection_id"] = new_id
             else:
-                self.selection_sets[existing_id] = merged
+                self.selection_sets[existing_id] = new_data
         else:
             # No link yet: only worth remembering if there is something to store.
             if not snapshot["files"] and not snapshot["folders"]:

--- a/src/gesturesesh/session_window.py
+++ b/src/gesturesesh/session_window.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import math
-import platform
 import random
 import sys
 from collections import OrderedDict
@@ -30,6 +29,7 @@ from gesturesesh.session.shortcuts import SessionShortcutsMixin
 from gesturesesh.session.timer import SessionTimerMixin
 from gesturesesh.session.zoom_pan import SessionZoomPanMixin
 from gesturesesh.utils import resources_config  # noqa: F401
+from gesturesesh.utils.file_reveal import reveal_in_file_manager
 from gesturesesh.ui.dialogs import (
     run_selection_order_dialog,
     run_shortcut_map_dialog,
@@ -1255,19 +1255,7 @@ class SessionDisplay(
 
     def open_image_directory(self, event=None):
         path = self.playlist[self.playlist_position]
-        if path.startswith(":/"):
-            return
-        resolved_path = str(Path(path).resolve())
-        system = platform.system()
-        if system == "Windows":
-            QtCore.QProcess.startDetached("explorer.exe", [f"/select,", resolved_path])
-        elif system == "Darwin":  # macOS
-            QtCore.QProcess.startDetached("open", ["-R", resolved_path])
-        else:  # Linux and other systems
-            # Use xdg-open for Linux
-            parent_dir = Path(resolved_path).parent
-            QtCore.QProcess.startDetached("xdg-open", [str(parent_dir)])
-        if event:
+        if reveal_in_file_manager(path) and event:
             event.accept()
 
     # endregion

--- a/src/gesturesesh/ui/dialogs.py
+++ b/src/gesturesesh/ui/dialogs.py
@@ -56,6 +56,7 @@ class ImageManagerDialog(QtWidgets.QDialog):
         validate_files=None,
         title="Selection Order",
         random_preview=False,
+        focus_missing=False,
     ):
         super().__init__(parent)
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose, True)
@@ -72,6 +73,7 @@ class ImageManagerDialog(QtWidgets.QDialog):
         self._current_index = current_index
         self._validate_files = validate_files
         self.random_preview = bool(random_preview)
+        self._focus_missing = bool(focus_missing)
         self.working_files = list(files)
         self.working_folders = list(folders or [])
         self._thumbnail_cache = {}
@@ -155,6 +157,13 @@ class ImageManagerDialog(QtWidgets.QDialog):
         self.add_folder_btn = QtWidgets.QPushButton("Add Folder", self)
         self.remove_selected_btn = QtWidgets.QPushButton("Remove Selected", self)
         self.remove_missing_btn = QtWidgets.QPushButton("Remove Missing", self)
+        self.show_missing_btn = QtWidgets.QPushButton("Show Missing", self)
+        self.show_missing_btn.setCheckable(True)
+        self.show_missing_btn.setToolTip("Show only files that are missing from disk.")
+        if self._focus_missing:
+            # Opened to review missing files: start filtered to just those.
+            self.show_missing_btn.setChecked(True)
+            self.show_missing_btn.setText("Show All")
         self.show_duplicates_btn = QtWidgets.QPushButton("Show Duplicates", self)
         self.show_duplicates_btn.setCheckable(True)
         self.move_up_btn = QtWidgets.QPushButton("Move Up", self)
@@ -175,6 +184,7 @@ class ImageManagerDialog(QtWidgets.QDialog):
             self.add_folder_btn,
             self.remove_selected_btn,
             self.remove_missing_btn,
+            self.show_missing_btn,
             self.show_duplicates_btn,
             self.move_up_btn,
             self.move_down_btn,
@@ -201,6 +211,7 @@ class ImageManagerDialog(QtWidgets.QDialog):
         self.add_folder_btn.clicked.connect(self._add_folder)
         self.remove_selected_btn.clicked.connect(self._remove_selected)
         self.remove_missing_btn.clicked.connect(self._remove_missing)
+        self.show_missing_btn.toggled.connect(self._toggle_show_missing)
         self.show_duplicates_btn.toggled.connect(self._toggle_show_duplicates)
         self.move_up_btn.clicked.connect(lambda: self._move_selected(-1))
         self.move_down_btn.clicked.connect(lambda: self._move_selected(1))
@@ -412,13 +423,14 @@ class ImageManagerDialog(QtWidgets.QDialog):
         self._pending_thumbnail_keys = set()
         self._thumbnail_generation += 1
         query = self.search_input.text().strip().lower()
+        show_missing_only = self.show_missing_btn.isChecked()
         self.images_list.clear()
         has_locked_rows = any(
             self._is_locked_index(index) for index in range(len(self.working_files))
         )
         self.images_list.setDragDropMode(
             QtWidgets.QAbstractItemView.NoDragDrop
-            if query or has_locked_rows
+            if query or has_locked_rows or show_missing_only
             else QtWidgets.QAbstractItemView.InternalMove
         )
         visible = 0
@@ -437,11 +449,14 @@ class ImageManagerDialog(QtWidgets.QDialog):
                 continue
 
             is_break = file_path == BREAK_IMAGE_PATH
+            if not is_break:
+                real_seen += 1
+            is_missing = not is_break and not os.path.exists(file_path)
+            if show_missing_only and not is_missing:
+                continue
             is_duplicate = index in duplicate_indices
             is_locked = self._is_locked_index(index)
             is_current = self._current_index == index
-            if not is_break:
-                real_seen += 1
 
             markers = []
             if is_break:
@@ -454,7 +469,7 @@ class ImageManagerDialog(QtWidgets.QDialog):
                 markers.append("LOCKED")
             if show_duplicates and is_duplicate:
                 markers.append("DUPLICATE")
-            if file_path != BREAK_IMAGE_PATH and not os.path.exists(file_path):
+            if is_missing:
                 markers.append("MISSING")
 
             display_name = "Break" if is_break else os.path.basename(file_path)
@@ -467,7 +482,7 @@ class ImageManagerDialog(QtWidgets.QDialog):
 
             if is_locked:
                 item.setForeground(QtGui.QBrush(QtGui.QColor("#b8c4cc")))
-            if file_path != BREAK_IMAGE_PATH and not os.path.exists(file_path):
+            if is_missing:
                 item.setForeground(QtGui.QBrush(QtGui.QColor("#ff7f7f")))
             elif show_duplicates and is_duplicate:
                 item.setBackground(QtGui.QBrush(QtGui.QColor("#40361e")))
@@ -593,7 +608,15 @@ class ImageManagerDialog(QtWidgets.QDialog):
             for index, path in enumerate(self.working_files)
             if self._is_locked_index(index) or path == BREAK_IMAGE_PATH or os.path.exists(path)
         ]
-        self._refresh_list()
+        # If we were filtered to missing-only and nothing missing remains, drop
+        # the filter so the user isn't left looking at an empty list.
+        still_missing = any(
+            p != BREAK_IMAGE_PATH and not os.path.exists(p) for p in self.working_files
+        )
+        if self.show_missing_btn.isChecked() and not still_missing:
+            self.show_missing_btn.setChecked(False)  # triggers refresh via toggled
+        else:
+            self._refresh_list()
 
     def _move_selected(self, direction):
         indices = self._selected_indices()
@@ -681,6 +704,10 @@ class ImageManagerDialog(QtWidgets.QDialog):
         self.working_files = [
             path for index, path in enumerate(self.working_files) if self._is_locked_index(index)
         ]
+        self._refresh_list()
+
+    def _toggle_show_missing(self, checked):
+        self.show_missing_btn.setText("Show All" if checked else "Show Missing")
         self._refresh_list()
 
     def _toggle_show_duplicates(self, checked):

--- a/src/gesturesesh/ui/dialogs.py
+++ b/src/gesturesesh/ui/dialogs.py
@@ -25,6 +25,7 @@ from gesturesesh.app.selection_order import (
     selection_stats,
 )
 from gesturesesh.session.constants import is_hidden_file
+from gesturesesh.utils.file_reveal import reveal_in_file_manager
 
 
 class OrderListWidget(QtWidgets.QListWidget):
@@ -164,6 +165,9 @@ class ImageManagerDialog(QtWidgets.QDialog):
         self.sort_name_btn = QtWidgets.QPushButton("Sort Name", self)
         self.sort_path_btn = QtWidgets.QPushButton("Sort Path", self)
         self.open_folder_btn = QtWidgets.QPushButton("Open Folder", self)
+        self.open_folder_btn.setToolTip(
+            "Reveal the highlighted image in your file browser, selecting it."
+        )
         self.clear_all_btn = QtWidgets.QPushButton("Clear All", self)
 
         for widget in (
@@ -668,11 +672,10 @@ class ImageManagerDialog(QtWidgets.QDialog):
             return
 
         target = self.working_files[indices[0]]
-        folder = os.path.dirname(target)
-        if folder and os.path.isdir(folder):
-            QtGui.QDesktopServices.openUrl(
-                QtCore.QUrl.fromLocalFile(os.path.abspath(folder))
-            )
+        if target and target != BREAK_IMAGE_PATH:
+            # Reveal-and-select the highlighted image so it's easy to spot,
+            # mirroring the session window's "open folder" behavior.
+            reveal_in_file_manager(target)
 
     def _clear_all(self):
         self.working_files = [

--- a/src/gesturesesh/utils/file_reveal.py
+++ b/src/gesturesesh/utils/file_reveal.py
@@ -1,0 +1,51 @@
+"""Reveal a file in the OS file manager, highlighting it when possible.
+
+Shared by the session window and the Manage Order dialog so their
+"open folder" actions land on — and select — the specific image the user is
+looking at, instead of merely opening its containing directory.
+"""
+
+from __future__ import annotations
+
+import platform
+from pathlib import Path
+
+from PyQt5 import QtCore
+
+
+def reveal_in_file_manager(path: str) -> bool:
+    """Open the OS file manager with *path* highlighted.
+
+    On Windows and macOS the file itself is selected; Linux has no portable
+    "select" flag, so the containing folder is opened instead. If the file is
+    gone, fall back to opening its parent directory so the user still lands
+    nearby. Qt resource paths (``:/...``) and empty paths are ignored.
+
+    Returns ``True`` when a command was dispatched, ``False`` otherwise.
+    """
+    if not path or path.startswith(":/"):
+        return False
+
+    resolved = Path(path).resolve()
+    system = platform.system()
+
+    if resolved.exists():
+        if system == "Windows":
+            QtCore.QProcess.startDetached("explorer.exe", ["/select,", str(resolved)])
+        elif system == "Darwin":
+            QtCore.QProcess.startDetached("open", ["-R", str(resolved)])
+        else:  # Linux and other systems: no universal reveal-and-select.
+            QtCore.QProcess.startDetached("xdg-open", [str(resolved.parent)])
+        return True
+
+    # The file no longer exists; open its folder if that still does.
+    parent = resolved.parent
+    if not parent.is_dir():
+        return False
+    if system == "Windows":
+        QtCore.QProcess.startDetached("explorer.exe", [str(parent)])
+    elif system == "Darwin":
+        QtCore.QProcess.startDetached("open", [str(parent)])
+    else:
+        QtCore.QProcess.startDetached("xdg-open", [str(parent)])
+    return True

--- a/tests/test_file_reveal.py
+++ b/tests/test_file_reveal.py
@@ -1,0 +1,85 @@
+"""Tests for reveal_in_file_manager (utils/file_reveal.py)."""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
+
+from gesturesesh.utils.file_reveal import reveal_in_file_manager
+
+
+class TestRevealInFileManager(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.file = os.path.join(self.tmp, "img.png")
+        with open(self.file, "w") as f:
+            f.write("x")
+        self.resolved = str(Path(self.file).resolve())
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _patches(self, system):
+        return (
+            patch("gesturesesh.utils.file_reveal.platform.system", lambda: system),
+            patch("gesturesesh.utils.file_reveal.QtCore.QProcess.startDetached"),
+        )
+
+    def test_windows_selects_file(self):
+        sys_patch, start_patch = self._patches("Windows")
+        with sys_patch, start_patch as mock_start:
+            self.assertTrue(reveal_in_file_manager(self.file))
+            mock_start.assert_called_once_with(
+                "explorer.exe", ["/select,", self.resolved]
+            )
+
+    def test_macos_reveals_file(self):
+        sys_patch, start_patch = self._patches("Darwin")
+        with sys_patch, start_patch as mock_start:
+            self.assertTrue(reveal_in_file_manager(self.file))
+            mock_start.assert_called_once_with("open", ["-R", self.resolved])
+
+    def test_linux_opens_parent(self):
+        sys_patch, start_patch = self._patches("Linux")
+        with sys_patch, start_patch as mock_start:
+            self.assertTrue(reveal_in_file_manager(self.file))
+            mock_start.assert_called_once_with(
+                "xdg-open", [str(Path(self.resolved).parent)]
+            )
+
+    def test_resource_path_ignored(self):
+        sys_patch, start_patch = self._patches("Darwin")
+        with sys_patch, start_patch as mock_start:
+            self.assertFalse(reveal_in_file_manager(":/break.png"))
+            mock_start.assert_not_called()
+
+    def test_empty_path_ignored(self):
+        sys_patch, start_patch = self._patches("Darwin")
+        with sys_patch, start_patch as mock_start:
+            self.assertFalse(reveal_in_file_manager(""))
+            mock_start.assert_not_called()
+
+    def test_missing_file_falls_back_to_folder(self):
+        missing = os.path.join(self.tmp, "gone.png")
+        sys_patch, start_patch = self._patches("Darwin")
+        with sys_patch, start_patch as mock_start:
+            self.assertTrue(reveal_in_file_manager(missing))
+            mock_start.assert_called_once_with(
+                "open", [str(Path(missing).resolve().parent)]
+            )
+
+    def test_missing_file_and_folder_returns_false(self):
+        missing = os.path.join(self.tmp, "nope", "gone.png")
+        sys_patch, start_patch = self._patches("Darwin")
+        with sys_patch, start_patch as mock_start:
+            self.assertFalse(reveal_in_file_manager(missing))
+            mock_start.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_selection_sets.py
+++ b/tests/test_selection_sets.py
@@ -245,6 +245,177 @@ class TestSelectionSets(unittest.TestCase):
         self.app.apply_selection_set("does-not-exist")
         self.assertEqual(self.app.selection, {"files": ["/keep.png"], "folders": ["/keep"]})
 
+    # -- unavailable reporting -------------------------------------------------
+
+    def test_active_set_unavailable_lists_missing_files_and_folders(self):
+        present = self._touch("here.png")
+        gone = os.path.join(self.test_dir, "gone.png")
+        missing_dir = os.path.join(self.test_dir, "no_such_dir")
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
+        self.app.selection_sets = {
+            "set1": {"files": [present, gone], "folders": [self.test_dir, missing_dir]}
+        }
+        self.app._active_set_preset = "A"
+
+        result = self.app._active_set_unavailable()
+
+        self.assertEqual(result["files"], [gone])
+        self.assertEqual(result["folders"], [missing_dir])
+
+    def test_active_set_unavailable_empty_when_all_present(self):
+        present = self._touch("here.png")
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
+        self.app.selection_sets = {
+            "set1": {"files": [present], "folders": [self.test_dir]}
+        }
+        self.app._active_set_preset = "A"
+
+        self.assertEqual(
+            self.app._active_set_unavailable(), {"files": [], "folders": []}
+        )
+
+    def test_active_set_unavailable_empty_without_active_preset(self):
+        self.app._active_set_preset = None
+        self.assertEqual(
+            self.app._active_set_unavailable(), {"files": [], "folders": []}
+        )
+
+    def test_active_set_unavailable_empty_when_preset_has_no_link(self):
+        self.app.presets = {"A": {"schedule": {}}}  # no selection_id
+        self.app._active_set_preset = "A"
+        self.assertEqual(
+            self.app._active_set_unavailable(), {"files": [], "folders": []}
+        )
+
+    # -- authoritative write (Manage Order curation) ---------------------------
+
+    def test_authoritative_write_drops_offline_file_user_removed(self):
+        # An offline file (whole dir gone) the user removed in Manage Order must
+        # stay removed, even though the boundary merge would normally preserve it.
+        present = self._touch("keep.png")
+        offline = "/mnt/usb/gone.png"  # parent dir missing -> reads as offline
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
+        self.app.selection_sets = {"set1": {"files": [present, offline], "folders": []}}
+        self.app._active_set_preset = "A"
+
+        self.app.write_back_active_set(
+            snapshot={"files": [present], "folders": []}, authoritative=True
+        )
+
+        self.assertEqual(
+            self.app.selection_sets["set1"], {"files": [present], "folders": []}
+        )
+
+    def test_authoritative_write_keeps_supplied_missing_files(self):
+        present = self._touch("keep.png")
+        offline = "/mnt/usb/later.png"
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
+        self.app.selection_sets = {"set1": {"files": [present], "folders": []}}
+        self.app._active_set_preset = "A"
+
+        self.app.write_back_active_set(
+            snapshot={"files": [present, offline], "folders": []},
+            authoritative=True,
+        )
+
+        self.assertEqual(
+            self.app.selection_sets["set1"],
+            {"files": [present, offline], "folders": []},
+        )
+
+    def test_authoritative_write_forks_shared_set(self):
+        present = self._touch("keep.png")
+        self.app.presets = {
+            "A": {"schedule": {}, "selection_id": "set1"},
+            "B": {"schedule": {}, "selection_id": "set1"},
+        }
+        self.app.selection_sets = {"set1": {"files": ["/x.png"], "folders": []}}
+        self.app._active_set_preset = "B"
+
+        self.app.write_back_active_set(
+            snapshot={"files": [present], "folders": []}, authoritative=True
+        )
+
+        # A keeps the shared set; B forks its own.
+        self.assertEqual(self.app.presets["A"]["selection_id"], "set1")
+        new_id = self.app.presets["B"]["selection_id"]
+        self.assertNotEqual(new_id, "set1")
+        self.assertEqual(
+            self.app.selection_sets[new_id], {"files": [present], "folders": []}
+        )
+        self.assertEqual(
+            self.app.selection_sets["set1"], {"files": ["/x.png"], "folders": []}
+        )
+
+    # -- Manage Order viewer integration ---------------------------------------
+
+    def _prime_viewer_app(self, set_files):
+        """Set up an active preset + live selection for viewer tests."""
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
+        self.app.selection_sets = {"set1": {"files": list(set_files), "folders": []}}
+        self.app._active_set_preset = "A"
+        loadable = [f for f in set_files if os.path.isfile(f)]
+        self.app.selection = {"files": loadable, "folders": []}
+        self.app.session_schedule = []
+        self.app.grab_schedule = types.MethodType(lambda s: None, self.app)
+        self.app.randomize_selection.isChecked = lambda: False
+
+    def test_viewer_feeds_missing_files_as_rows(self):
+        present = self._touch("keep.png")
+        offline = "/mnt/usb/gone.png"
+        self._prime_viewer_app([present, offline])
+
+        with patch(
+            "gesturesesh.app.selection.run_selection_order_dialog",
+            return_value={"files": [present], "folders": [], "random_preview": False},
+        ) as mock_dialog:
+            self.app.open_selection_order_viewer()
+
+        # The viewer received the loaded file AND the missing one (as a row).
+        _, kwargs = mock_dialog.call_args
+        self.assertEqual(kwargs["files"], [present, offline])
+
+    def test_viewer_removing_missing_file_sticks(self):
+        present = self._touch("keep.png")
+        offline = "/mnt/usb/gone.png"  # offline drive -> merge would resurrect it
+        self._prime_viewer_app([present, offline])
+
+        # User removes the MISSING row and applies.
+        with patch(
+            "gesturesesh.app.selection.run_selection_order_dialog",
+            return_value={"files": [present], "folders": [], "random_preview": False},
+        ):
+            self.app.open_selection_order_viewer()
+
+        self.assertEqual(
+            self.app.selection_sets["set1"], {"files": [present], "folders": []}
+        )
+        self.assertEqual(self.app.selection["files"], [present])
+
+    def test_viewer_keeping_missing_file_preserves_in_set_not_live(self):
+        present = self._touch("keep.png")
+        offline = "/mnt/usb/later.png"
+        self._prime_viewer_app([present, offline])
+
+        # User keeps the MISSING row and applies.
+        with patch(
+            "gesturesesh.app.selection.run_selection_order_dialog",
+            return_value={
+                "files": [present, offline],
+                "folders": [],
+                "random_preview": False,
+            },
+        ):
+            self.app.open_selection_order_viewer()
+
+        # Kept in the preset for when the drive returns...
+        self.assertEqual(
+            self.app.selection_sets["set1"],
+            {"files": [present, offline], "folders": []},
+        )
+        # ...but excluded from the live, loadable-only selection.
+        self.assertEqual(self.app.selection["files"], [present])
+
     # -- switch handler --------------------------------------------------------
 
     def test_on_preset_switch_writes_old_and_applies_new(self):

--- a/tests/test_selection_sets.py
+++ b/tests/test_selection_sets.py
@@ -354,7 +354,7 @@ class TestSelectionSets(unittest.TestCase):
         self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
         self.app.selection_sets = {"set1": {"files": list(set_files), "folders": []}}
         self.app._active_set_preset = "A"
-        loadable = [f for f in set_files if os.path.isfile(f)]
+        loadable = self.app.check_files(set_files)["valid_files"]
         self.app.selection = {"files": loadable, "folders": []}
         self.app.session_schedule = []
         self.app.grab_schedule = types.MethodType(lambda s: None, self.app)
@@ -414,6 +414,58 @@ class TestSelectionSets(unittest.TestCase):
             {"files": [present, offline], "folders": []},
         )
         # ...but excluded from the live, loadable-only selection.
+        self.assertEqual(self.app.selection["files"], [present])
+
+    def test_viewer_preserves_stored_order_on_unchanged_apply(self):
+        # Regression: missing entries must keep their stored position so an
+        # unchanged Apply does not reorder the set (Codex P2).
+        present = self._touch("present.png")
+        missing = "/mnt/usb/missing.png"  # stored BEFORE the present file
+        self._prime_viewer_app([missing, present])
+
+        def echo(*a, **k):
+            # Dialog echoes back exactly what it was shown (Apply, no edits).
+            return {
+                "files": list(k["files"]),
+                "folders": list(k["folders"]),
+                "random_preview": False,
+            }
+
+        with patch(
+            "gesturesesh.app.selection.run_selection_order_dialog", side_effect=echo
+        ) as mock_dialog:
+            self.app.open_selection_order_viewer()
+
+        # Missing item is reinserted at its stored position, not appended.
+        self.assertEqual(mock_dialog.call_args.kwargs["files"], [missing, present])
+        # Round trip preserves saved order instead of [present, missing].
+        self.assertEqual(self.app.selection_sets["set1"]["files"], [missing, present])
+
+    def test_viewer_keeps_invalid_existing_file_out_of_live(self):
+        # Regression: an existing but unsupported saved path (e.g. an AppleDouble
+        # sidecar) must not re-enter the live selection (Codex P2).
+        present = self._touch("present.png")
+        sidecar = self._touch("note.txt")  # exists, but unsupported extension
+
+        self._prime_viewer_app([present, sidecar])
+
+        def echo(*a, **k):
+            return {
+                "files": list(k["files"]),
+                "folders": list(k["folders"]),
+                "random_preview": False,
+            }
+
+        with patch(
+            "gesturesesh.app.selection.run_selection_order_dialog", side_effect=echo
+        ):
+            self.app.open_selection_order_viewer()
+
+        # Stored set keeps the user's full curated list...
+        self.assertEqual(
+            self.app.selection_sets["set1"]["files"], [present, sidecar]
+        )
+        # ...but the live selection excludes the unsupported file.
         self.assertEqual(self.app.selection["files"], [present])
 
     # -- switch handler --------------------------------------------------------


### PR DESCRIPTION
## Summary

Two related improvements to how a preset's image set is handled when files move
or drives disconnect, centered on the Manage Order window.

### Reveal the highlighted image in the file manager
"Open Folder" now reveals **and selects** the highlighted image in the OS file
manager instead of just opening its folder, so it's easy to spot. The
platform-specific logic (Windows `/select`, macOS `open -R`, Linux folder-open,
with a missing-file → parent-dir fallback) is extracted into a shared
`reveal_in_file_manager` helper used by both the session window and the dialog.

### Surface a preset's unavailable files so the user can see and fix them
Switching to a preset whose saved set has missing/moved files used to flash a
bare count with no detail. Now:
- The status directs the user to Manage Order ("…N not found. Open Manage Order
  to review them.").
- Missing files appear in Manage Order as red **MISSING** rows (full paths) and
  can be removed with the existing "Remove Missing" button.
- A new **"Show Missing"** filter isolates just the missing files in a large
  list; Manage Order opens pre-filtered when launched to review them, and clears
  the filter once nothing missing remains.
- The viewer opens even when nothing currently loads (e.g. a disconnected
  drive), so the list is still reachable.

## Implementation notes
- When the viewer shows the full set, its Apply result is written
  **authoritatively** (`write_back_active_set(authoritative=True)` skips the
  offline-preserving merge), so a "Remove Missing" sticks even for offline-drive
  files. Kept-missing entries stay saved in the preset and return when the
  file/drive is back; the live selection keeps only loadable entries.
- Linux has no portable "select this file" flag, so the reveal falls back to
  opening the containing folder there.

## Testing
- `tests/test_file_reveal.py` — reveal helper across Windows/macOS/Linux + edge cases.
- `tests/test_selection_sets.py` — `_active_set_unavailable`, authoritative write
  (incl. offline-file removal sticking), and viewer integration.
- Full suite: 98 passed, 2 skipped.

