### PR TITLE
Release v0.5.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version number (e.g., v0.5.4)'
+        description: 'Version number (e.g., v0.5.6)'
         required: true
-        default: 'v0.5.4'
+        default: 'v0.5.6'
 
 permissions:
   contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -662,7 +662,7 @@ jobs:
         #### Windows (PowerShell)
         ```powershell
         # Get checksum of downloaded file
-        Get-FileHash -Algorithm SHA256 GestureSesh-v0.5.4-Windows-x64.exe
+        Get-FileHash -Algorithm SHA256 GestureSesh-v0.5.6-Windows-x64.exe
         
         # Compare with official checksum from checksums.txt
         ```
@@ -670,7 +670,7 @@ jobs:
         #### macOS/Linux
         ```bash
         # Get checksum of downloaded file
-        shasum -a 256 GestureSesh-v0.5.4-macOS.dmg
+        shasum -a 256 GestureSesh-v0.5.6-macOS.dmg
         
         # Compare with official checksum from checksums.txt
         ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - macOS AppleDouble sidecar files (`._name.ext`) and other hidden dotfiles are no longer added to selections. They mirror a real image's extension but contain only metadata, so they were being queued and then failing to decode mid-session. They are now skipped silently when adding files or scanning folders.
 
 ### Added
+
+- **Presets remember their images** — switching to a preset now restores the
+  image selection (files and folders) you last used with it, so your reference
+  set comes back automatically instead of carrying over from the previous
+  preset. Presets that share the same selection stay linked until you change
+  one, and a set is never dropped while a preset still uses it.
 - **Manage Order** can now reveal the highlighted image directly in your file
   browser (Windows/macOS select the file; Linux opens its folder), and a new
   **Show Missing** filter isolates files that are missing from disk.
 
 ### Changed
+
 - Switching to a preset with missing/moved images now points you to Manage
   Order, where the missing files are listed as removable **MISSING** rows
   instead of just reporting a count. Removing them there sticks, while files on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Photos carrying an EXIF orientation tag (most phone and camera images) once again display upright during sessions. The image-loading refactor in v0.5.4 routed every format through `cv2.imdecode(..., IMREAD_UNCHANGED)`, which ignores EXIF orientation, so images that auto-rotated under v0.5.1's `IMREAD_COLOR` path began appearing rotated 90°. The orientation tag is now read and re-applied after decoding, preserving the alpha channel and bit depth.
 - macOS AppleDouble sidecar files (`._name.ext`) and other hidden dotfiles are no longer added to selections. They mirror a real image's extension but contain only metadata, so they were being queued and then failing to decode mid-session. They are now skipped silently when adding files or scanning folders.
 
+### Added
+- **Manage Order** can now reveal the highlighted image directly in your file
+  browser (Windows/macOS select the file; Linux opens its folder), and a new
+  **Show Missing** filter isolates files that are missing from disk.
+
+### Changed
+- Switching to a preset with missing/moved images now points you to Manage
+  Order, where the missing files are listed as removable **MISSING** rows
+  instead of just reporting a count. Removing them there sticks, while files on
+  a temporarily disconnected drive stay saved in the preset and return when the
+  drive is back.
+  
 ## v0.5.5 - 2026-05-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to GestureSesh will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.5.6 - 2026-06-21
+
+### Fixed
+
+- Photos carrying an EXIF orientation tag (most phone and camera images) once again display upright during sessions. The image-loading refactor in v0.5.4 routed every format through `cv2.imdecode(..., IMREAD_UNCHANGED)`, which ignores EXIF orientation, so images that auto-rotated under v0.5.1's `IMREAD_COLOR` path began appearing rotated 90°. The orientation tag is now read and re-applied after decoding, preserving the alpha channel and bit depth.
+- macOS AppleDouble sidecar files (`._name.ext`) and other hidden dotfiles are no longer added to selections. They mirror a real image's extension but contain only metadata, so they were being queued and then failing to decode mid-session. They are now skipped silently when adding files or scanning folders.
+
 ## v0.5.5 - 2026-05-25
 
 ### Fixed

--- a/GestureSesh_macOS.spec
+++ b/GestureSesh_macOS.spec
@@ -53,6 +53,6 @@ app = BUNDLE(
     name='GestureSesh.app',
     icon='ui/resources/icons/brush.icns',
     bundle_identifier='com.gesturesesh.gesturesesh',
-    version='0.5.5',
+    version='0.5.6',
     codesign_identity=os.environ.get('CODESIGN_IDENTITY'),
 )

--- a/src/gesturesesh/__init__.py
+++ b/src/gesturesesh/__init__.py
@@ -4,7 +4,7 @@ GestureSesh - A drawing practice application for artists.
 This package contains the core functionality for the GestureSesh application.
 """
 
-__version__ = "0.5.4"
+__version__ = "0.5.6"
 __author__ = "adnv3k"
 __email__ = "ali@adnv3k.com"
 

--- a/src/gesturesesh/app/presets.py
+++ b/src/gesturesesh/app/presets.py
@@ -24,30 +24,57 @@ class MainAppPresetsMixin:
         # with stale in-memory picks from the current app run.
         self.selection["files"] = []
         self.selection["folders"] = []
-
-        folders = recent.get("folders", [])
-        files = recent.get("files", [])
         loaded_any = False
-        if folders:
-            self.selection["folders"] = folders
-            self.scan_directories(folders)
-            loaded_any = True
-        if files:
-            checked = self.check_files(files)
-            self.selection["files"].extend(
-                file for file in checked["valid_files"] if file != BREAK_IMAGE_PATH
-            )
-            loaded_any = loaded_any or bool(checked["valid_files"])
 
-        # Preserve order while dropping accidental duplicates.
-        self.selection["files"] = list(dict.fromkeys(self.selection["files"]))
+        # Restore the recent preset first (guarded so programmatic combo changes
+        # don't trigger selection-set writes), then resolve which set the
+        # selection should come from.
+        self._loading = True
+        try:
+            if "recent_preset" in recent:
+                self.preset_loader_box.setCurrentIndex(recent.get("recent_preset", 0))
+                loaded_any = True
+            if "randomized" in recent:
+                self.randomize_selection.setChecked(recent.get("randomized", False))
+                loaded_any = True
+            name = self.preset_loader_box.currentText()
+            self._active_set_preset = name if name in self.presets else None
+        finally:
+            self._loading = False
 
-        if "recent_preset" in recent:
-            self.preset_loader_box.setCurrentIndex(recent.get("recent_preset", 0))
+        # The linked image set wins as the source of truth for the selection.
+        preset = (
+            self.presets.get(self._active_set_preset)
+            if self._active_set_preset
+            else None
+        )
+        set_id = preset.get("selection_id") if isinstance(preset, dict) else None
+
+        if set_id and set_id in self.selection_sets:
+            self.apply_selection_set(set_id)
             loaded_any = True
-        if "randomized" in recent:
-            self.randomize_selection.setChecked(recent.get("randomized", False))
-            loaded_any = True
+        else:
+            # No linked set: fall back to the recent file/folder list, then
+            # migrate it into a set for the active preset (one-time upgrade for
+            # pre-existing configs).
+            folders = recent.get("folders", [])
+            files = recent.get("files", [])
+            if folders:
+                self.selection["folders"] = folders
+                self.scan_directories(folders)
+                loaded_any = True
+            if files:
+                checked = self.check_files(files)
+                self.selection["files"].extend(
+                    file
+                    for file in checked["valid_files"]
+                    if file != BREAK_IMAGE_PATH
+                )
+                loaded_any = loaded_any or bool(checked["valid_files"])
+            # Preserve order while dropping accidental duplicates.
+            self.selection["files"] = list(dict.fromkeys(self.selection["files"]))
+            if self._active_set_preset:
+                self.write_back_active_set()
 
         self.remove_breaks()
         self.display_status()
@@ -239,11 +266,22 @@ class MainAppPresetsMixin:
             self.presets[preset_name] = {"schedule": schedule}
         self.config["presets"] = self.presets
         if preset_name not in self.preset_names:
-            self.update_presets()
-            self.preset_loader_box.setCurrentIndex(self.preset_loader_box.count() - 1)
+            self._loading = True
+            try:
+                self.update_presets()
+                self.preset_loader_box.setCurrentIndex(
+                    self.preset_loader_box.count() - 1
+                )
+            finally:
+                self._loading = False
         if wait_status:
             self.show_temporary_status(f"{preset_name} saved!", 3000)
         save_config(self.config_path, self.config)
+        # Associate the live selection with the saved preset: new presets adopt
+        # the current selection; re-saves refresh the link (copy-on-write if the
+        # set is shared). No-op when the selection matches the existing set.
+        self._active_set_preset = preset_name
+        self.write_back_active_set()
 
     def delete(self):
         preset_name = self.preset_loader_box.currentText()
@@ -253,9 +291,19 @@ class MainAppPresetsMixin:
         if preset_name in self.presets:
             del self.presets[preset_name]
             self.config["presets"] = self.presets
+            # Cull any image set the deleted preset was the last to reference.
+            self._gc_selection_sets()
+            self.config["selection_sets"] = self.selection_sets
             save_config(self.config_path, self.config)
         self.show_temporary_status(f"{preset_name} deleted!", 2000)
-        self.preset_loader_box.removeItem(self.preset_loader_box.currentIndex())
+        self._loading = True
+        try:
+            self.preset_loader_box.removeItem(self.preset_loader_box.currentIndex())
+        finally:
+            self._loading = False
+        if self._active_set_preset == preset_name:
+            current = self.preset_loader_box.currentText()
+            self._active_set_preset = current if current in self.presets else None
 
     def load(self):
         preset_name = self.preset_loader_box.currentText()

--- a/src/gesturesesh/app/presets.py
+++ b/src/gesturesesh/app/presets.py
@@ -302,8 +302,26 @@ class MainAppPresetsMixin:
         finally:
             self._loading = False
         if self._active_set_preset == preset_name:
+            # The active preset was deleted and the combo has fallen to an
+            # adjacent entry (already loaded by the index-change -> load
+            # wiring). The live selection still belongs to the deleted preset,
+            # so it must not reach the fallback's set on the next boundary
+            # write.
             current = self.preset_loader_box.currentText()
-            self._active_set_preset = current if current in self.presets else None
+            fallback = current if current in self.presets else None
+            preset = self.presets.get(fallback) if fallback else None
+            set_id = preset.get("selection_id") if isinstance(preset, dict) else None
+            if set_id:
+                # Treat this as a switch-in to the fallback: adopt it and apply
+                # its saved set so the live selection matches it.
+                self._active_set_preset = fallback
+                self.apply_selection_set(set_id)
+            else:
+                # Nothing to switch to: drop the active link so a later boundary
+                # write is a no-op instead of overwriting the fallback's set
+                # with the deleted preset's stale selection. A deliberate switch
+                # re-establishes tracking.
+                self._active_set_preset = None
 
     def load(self):
         preset_name = self.preset_loader_box.currentText()

--- a/src/gesturesesh/app/selection.py
+++ b/src/gesturesesh/app/selection.py
@@ -177,7 +177,10 @@ class MainAppSelectionMixin:
 
     def open_selection_order_viewer(self):
         """Open the selection viewer/order editor from the main window."""
-        if not self.selection["files"]:
+        unavailable = self._active_set_unavailable()
+        if not self.selection["files"] and not (
+            unavailable["files"] or unavailable["folders"]
+        ):
             self.show_error_status("No images selected to manage.", 2500)
             return
 
@@ -187,24 +190,44 @@ class MainAppSelectionMixin:
             self.session_schedule = []
 
         random_preview = bool(self.randomize_selection.isChecked())
-        files = effective_selection_order(
-            self.selection["files"], randomize=random_preview
-        )
+        # Surface the active preset's saved-but-missing entries as MISSING rows
+        # the user can see and act on (Remove Missing), instead of dropping them
+        # silently. Reinsert them at their stored positions (not appended) so an
+        # unchanged Apply preserves saved order; randomize then shuffles all.
+        files = self._merge_missing_into_order(self.selection["files"])
+        files = effective_selection_order(files, randomize=random_preview)
+        folders = list(self.selection["folders"])
+        folders += [d for d in unavailable["folders"] if d not in set(folders)]
+
         result = run_selection_order_dialog(
             parent=self,
             files=files,
-            folders=self.selection["folders"],
+            folders=folders,
             schedule=self.session_schedule,
             valid_file_types=self.valid_file_types,
             duplicate_indices_fn=duplicate_indices,
             title="Selection Order",
             random_preview=random_preview,
+            focus_missing=bool(unavailable["files"] or unavailable["folders"]),
         )
         if result is None:
             return
 
-        self.selection["files"] = result["files"]
-        self.selection["folders"] = result["folders"]
+        # The viewer showed every entry (including missing ones), so its result
+        # is the authoritative set for this preset: persist it directly so that
+        # "Remove Missing" sticks even for offline-drive files. The live
+        # selection then keeps only what is currently loadable.
+        self.write_back_active_set(
+            snapshot={
+                "files": list(result["files"]),
+                "folders": list(result["folders"]),
+            },
+            authoritative=True,
+        )
+        # Revalidate (not just isfile): drop unsupported or hidden paths such as
+        # AppleDouble sidecars so the next session never tries to decode them.
+        self.selection["files"] = self.check_files(result["files"])["valid_files"]
+        self.selection["folders"] = [d for d in result["folders"] if os.path.isdir(d)]
         if result.get("random_preview"):
             self.randomize_selection.setChecked(False)
             self.show_temporary_status(

--- a/src/gesturesesh/app/selection.py
+++ b/src/gesturesesh/app/selection.py
@@ -11,6 +11,7 @@ from gesturesesh.app.selection_order import (
     duplicate_indices,
     effective_selection_order,
 )
+from gesturesesh.session.constants import is_hidden_file
 from gesturesesh.ui.dialogs import run_selection_order_dialog
 
 
@@ -122,6 +123,11 @@ class MainAppSelectionMixin:
         """Checks if files are supported file types and are accessible."""
         res = {"valid_files": [], "invalid_files": []}
         for file in files:
+            # Hidden dotfiles and macOS AppleDouble sidecars (._name.ext) are OS
+            # noise, not user images; skip them silently so they are neither
+            # added nor counted as unsupported files.
+            if is_hidden_file(file):
+                continue
             ext = os.path.splitext(file)[1].lower()
             if ext not in self.valid_file_types:
                 res["invalid_files"].append(file)

--- a/src/gesturesesh/app/selection_sets.py
+++ b/src/gesturesesh/app/selection_sets.py
@@ -1,0 +1,257 @@
+"""Per-preset image-set associations (phase 1: under-the-hood, no UI).
+
+An *image set* is a named-by-id snapshot of the selection (``files`` + ``folders``)
+that a preset can be linked to. The data model is normalized: presets hold a
+``selection_id`` reference and the sets themselves live once in
+``config["selection_sets"]`` keyed by a stable id, so multiple presets can share
+one set without duplicating the file list.
+
+Lifecycle rules (agreed design):
+
+* **Read on switch-in** – when the user deliberately switches to a preset, its
+  linked set is applied to the live selection (lazy validation + status report).
+* **Write on boundaries** – the live selection is written back to the active
+  preset's set only at clean boundaries (switching away, session start, app
+  close, explicit save), never on every edit. Reads and writes are kept on
+  separate triggers to avoid signal re-entrancy.
+* **Copy-on-write** – editing the selection for a preset whose set is shared by
+  another preset forks a new set for the current preset rather than mutating the
+  shared one.
+* **Garbage collection** – sets no longer referenced by any preset are culled
+  (which is also why a still-linked set can never be dropped).
+* **Offline safety** – when a set is applied while files are unavailable (e.g. an
+  unplugged external drive), only the available files load, but the write-back
+  preserves the unavailable ones instead of pruning them, so reconnecting the
+  drive brings the set back intact. Reconnect recovery: switch to another preset
+  and back to re-apply.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+from gesturesesh.utils.config import save_config
+
+
+class MainAppSelectionSetsMixin:
+    """Image-set association behavior mixed into ``MainApp``."""
+
+    def init_selection_sets(self):
+        """Initialize the in-memory store from config. Call after ``init_preset``."""
+        sets = self.config.get("selection_sets", {})
+        if not isinstance(sets, dict):
+            sets = {}
+        self.selection_sets = sets
+        self.config["selection_sets"] = self.selection_sets
+        # Name of the preset whose set the live selection currently represents.
+        # ``None`` means there is no real preset to write back to (e.g. the
+        # "Default" placeholder or an unsaved typed name).
+        self._active_set_preset = None
+
+    # -- helpers ---------------------------------------------------------------
+
+    def _new_set_id(self) -> str:
+        """Return a stable id not currently used by any set."""
+        while True:
+            set_id = uuid.uuid4().hex[:12]
+            if set_id not in self.selection_sets:
+                return set_id
+
+    def _selection_snapshot(self) -> dict:
+        """Snapshot the live selection (order preserved)."""
+        return {
+            "files": list(self.selection["files"]),
+            "folders": list(self.selection["folders"]),
+        }
+
+    def _set_refcount(self, set_id: str) -> int:
+        """How many presets reference *set_id*."""
+        return sum(
+            1
+            for preset in self.presets.values()
+            if isinstance(preset, dict) and preset.get("selection_id") == set_id
+        )
+
+    def _wrapped_preset(self, name: str) -> dict:
+        """Return *name*'s preset in wrapped form, upgrading legacy entries."""
+        preset = self.presets.get(name)
+        if not isinstance(preset, dict) or "schedule" not in preset:
+            preset = {"schedule": preset if isinstance(preset, dict) else {}}
+            self.presets[name] = preset
+        return preset
+
+    @staticmethod
+    def _is_offline(path: str) -> bool:
+        """True when *path*'s file is gone *and* its directory is too.
+
+        The heuristic distinguishes a disconnected drive / moved tree (the whole
+        directory is missing -> preserve) from an in-place deletion (the folder
+        still exists, the file was removed -> don't preserve). This keeps
+        external-drive workflows intact: unplugging a drive removes its mount
+        point, so every file under it reads as offline.
+        """
+        if os.path.isfile(path):
+            return False
+        parent = os.path.dirname(path) or os.sep
+        return not os.path.isdir(parent)
+
+    @staticmethod
+    def _is_offline_dir(path: str) -> bool:
+        """Folder variant of :meth:`_is_offline`."""
+        if os.path.isdir(path):
+            return False
+        parent = os.path.dirname(path.rstrip(os.sep)) or os.sep
+        return not os.path.isdir(parent)
+
+    def _merge_unavailable(self, snapshot: dict, stored: dict) -> dict:
+        """Reconcile the live selection with a stored set, preserving entries
+        that are absent only because their drive/tree is disconnected.
+
+        * No real edit (the live selection equals what the stored set currently
+          resolves to on disk) -> return the stored set verbatim, so a
+          disconnected drive never churns order or drops files.
+        * Real edit -> honor the user's order/edits for the visible items, then
+          re-append still-offline entries so they survive.
+        """
+        working_files = list(snapshot["files"])
+        working_folders = list(snapshot["folders"])
+        stored_files = list(stored.get("files", []))
+        stored_folders = list(stored.get("folders", []))
+
+        loadable_files = [f for f in stored_files if os.path.isfile(f)]
+        loadable_folders = [d for d in stored_folders if os.path.isdir(d)]
+
+        if working_files == loadable_files and working_folders == loadable_folders:
+            return {"files": stored_files, "folders": stored_folders}
+
+        working_fset = set(working_files)
+        reserved_files = [
+            f
+            for f in stored_files
+            if f not in working_fset and self._is_offline(f)
+        ]
+        working_dset = set(working_folders)
+        reserved_folders = [
+            d
+            for d in stored_folders
+            if d not in working_dset and self._is_offline_dir(d)
+        ]
+        return {
+            "files": working_files + reserved_files,
+            "folders": working_folders + reserved_folders,
+        }
+
+    def _gc_selection_sets(self) -> None:
+        """Remove sets not referenced by any preset (orphans only)."""
+        referenced = {
+            preset.get("selection_id")
+            for preset in self.presets.values()
+            if isinstance(preset, dict) and preset.get("selection_id")
+        }
+        for set_id in list(self.selection_sets.keys()):
+            if set_id not in referenced:
+                del self.selection_sets[set_id]
+
+    # -- read / write ----------------------------------------------------------
+
+    def apply_selection_set(self, set_id: str) -> None:
+        """Switch-in read: load *set_id* into the live selection.
+
+        Lazy validation: paths are applied as-is, then the ones that no longer
+        exist are dropped from the working selection and reported. A missing set
+        id is a no-op so the current selection is left untouched.
+        """
+        data = self.selection_sets.get(set_id)
+        if not data:
+            return
+        stored_files = list(data.get("files", []))
+        stored_folders = list(data.get("folders", []))
+
+        valid_files = self.check_files(stored_files)["valid_files"]
+        valid_folders = [f for f in stored_folders if os.path.isdir(f)]
+
+        self.selection["files"] = valid_files
+        self.selection["folders"] = valid_folders
+
+        missing = len(stored_files) - len(valid_files)
+        if missing > 0:
+            self.show_temporary_status(
+                f"Loaded {len(valid_files)} of {len(stored_files)} images "
+                f"— {missing} currently unavailable (kept in this preset).",
+                4000,
+            )
+        self.display_status()
+
+    def write_back_active_set(self) -> None:
+        """Boundary write: persist the live selection to the active preset's set.
+
+        Applies copy-on-write when the current set is shared, creates a set on
+        first write, GCs orphans, and persists. A no-op when there is no real
+        active preset or when nothing changed.
+        """
+        if getattr(self, "_loading", False):
+            return
+        name = self._active_set_preset
+        if not name or name not in self.presets:
+            return
+
+        snapshot = self._selection_snapshot()
+        preset = self._wrapped_preset(name)
+        existing_id = preset.get("selection_id")
+
+        if existing_id and existing_id in self.selection_sets:
+            stored = self.selection_sets[existing_id]
+            # Preserve entries missing only because their drive/tree is
+            # disconnected; never let an offline drive prune the stored set.
+            merged = self._merge_unavailable(snapshot, stored)
+            if merged == stored:
+                return  # no real change
+            if self._set_refcount(existing_id) > 1:
+                # shared + changed -> fork a new set for this preset
+                new_id = self._new_set_id()
+                self.selection_sets[new_id] = merged
+                preset["selection_id"] = new_id
+            else:
+                self.selection_sets[existing_id] = merged
+        else:
+            # No link yet: only worth remembering if there is something to store.
+            if not snapshot["files"] and not snapshot["folders"]:
+                return
+            new_id = self._new_set_id()
+            self.selection_sets[new_id] = snapshot
+            preset["selection_id"] = new_id
+
+        self.config["presets"] = self.presets
+        self._gc_selection_sets()
+        self.config["selection_sets"] = self.selection_sets
+        save_config(self.config_path, self.config)
+
+    # -- switch handler --------------------------------------------------------
+
+    def on_preset_switch(self, *args) -> None:
+        """Deliberate user preset switch: write back the old set, apply the new.
+
+        Wired to ``QComboBox.activated`` so it fires only on real user selection,
+        not on programmatic index changes or text editing.
+        """
+        if getattr(self, "_loading", False):
+            return
+        new_name = self.preset_loader_box.currentText()
+        if new_name == self._active_set_preset:
+            return
+
+        # Boundary write for the preset we are leaving (still the live selection).
+        self.write_back_active_set()
+
+        # Read for the preset we are entering.
+        self._active_set_preset = new_name if new_name in self.presets else None
+        if self._active_set_preset:
+            preset = self.presets.get(new_name)
+            set_id = (
+                preset.get("selection_id") if isinstance(preset, dict) else None
+            )
+            if set_id:
+                self.apply_selection_set(set_id)
+            # No linked set -> leave the current selection; it becomes this
+            # preset's set on the next boundary write.

--- a/src/gesturesesh/app/selection_sets.py
+++ b/src/gesturesesh/app/selection_sets.py
@@ -298,26 +298,31 @@ class MainAppSelectionSetsMixin:
     def on_preset_switch(self, *args) -> None:
         """Deliberate user preset switch: write back the old set, apply the new.
 
-        Wired to ``QComboBox.activated`` so it fires only on real user selection,
-        not on programmatic index changes or text editing.
+        Wired to ``QComboBox.activated`` (dropdown pick) and the editable line
+        edit's ``editingFinished`` (a typed name committed with Enter/focus-out),
+        so it runs on deliberate selection — not on programmatic index changes
+        or mid-typing text edits.
         """
         if getattr(self, "_loading", False):
             return
         new_name = self.preset_loader_box.currentText()
         if new_name == self._active_set_preset:
             return
+        if new_name not in self.presets:
+            # A typed, not-yet-saved name (Save As). This is not a switch:
+            # writing back here would persist the current selection — intended
+            # for the new preset — onto the OLD preset. Leave the active preset
+            # as-is; save() adopts the new name and stores the selection itself.
+            return
 
         # Boundary write for the preset we are leaving (still the live selection).
         self.write_back_active_set()
 
         # Read for the preset we are entering.
-        self._active_set_preset = new_name if new_name in self.presets else None
-        if self._active_set_preset:
-            preset = self.presets.get(new_name)
-            set_id = (
-                preset.get("selection_id") if isinstance(preset, dict) else None
-            )
-            if set_id:
-                self.apply_selection_set(set_id)
-            # No linked set -> leave the current selection; it becomes this
-            # preset's set on the next boundary write.
+        self._active_set_preset = new_name
+        preset = self.presets.get(new_name)
+        set_id = preset.get("selection_id") if isinstance(preset, dict) else None
+        if set_id:
+            self.apply_selection_set(set_id)
+        # No linked set -> leave the current selection; it becomes this preset's
+        # set on the next boundary write.

--- a/src/gesturesesh/app/selection_sets.py
+++ b/src/gesturesesh/app/selection_sets.py
@@ -177,18 +177,78 @@ class MainAppSelectionSetsMixin:
         missing = len(stored_files) - len(valid_files)
         if missing > 0:
             self.show_temporary_status(
-                f"Loaded {len(valid_files)} of {len(stored_files)} images "
-                f"— {missing} currently unavailable (kept in this preset).",
-                4000,
+                f"Loaded {len(valid_files)} of {len(stored_files)} images — "
+                f"{missing} not found. Open Manage Order to review them.",
+                5000,
             )
         self.display_status()
 
-    def write_back_active_set(self) -> None:
+    def _active_set_unavailable(self) -> dict:
+        """Files/folders linked to the active preset that aren't on disk now.
+
+        Lets the Manage Order viewer tell the user *which* saved entries a
+        preset switch could not load (they stay saved in the preset). Returns
+        empty lists when there is no active preset or it has no linked set.
+        """
+        name = getattr(self, "_active_set_preset", None)
+        preset = self.presets.get(name) if name else None
+        set_id = preset.get("selection_id") if isinstance(preset, dict) else None
+        data = self.selection_sets.get(set_id) if set_id else None
+        if not data:
+            return {"files": [], "folders": []}
+        stored_files = list(data.get("files", []))
+        loadable = set(self.check_files(stored_files)["valid_files"])
+        return {
+            "files": [f for f in stored_files if f not in loadable],
+            "folders": [d for d in data.get("folders", []) if not os.path.isdir(d)],
+        }
+
+    def _merge_missing_into_order(self, live_files):
+        """Return *live_files* with the active preset's stored-but-unavailable
+        entries reinserted at their stored positions.
+
+        The Manage Order viewer shows the full set and its result is written
+        back authoritatively, so appending missing items at the end would let an
+        unchanged Apply reorder the saved set (e.g. ``[missingA, presentB]`` ->
+        ``[presentB, missingA]``). Reinserting each unavailable entry just before
+        the next stored entry that is still loadable keeps the saved order stable
+        for a no-op round trip, while preserving live reordering and additions.
+        """
+        result = list(live_files)
+        name = getattr(self, "_active_set_preset", None)
+        preset = self.presets.get(name) if name else None
+        set_id = preset.get("selection_id") if isinstance(preset, dict) else None
+        data = self.selection_sets.get(set_id) if set_id else None
+        if not data:
+            return result
+        stored = list(data.get("files", []))
+        loadable = set(self.check_files(stored)["valid_files"])
+        live_set = set(live_files)
+        for index, path in enumerate(stored):
+            if path in loadable or path in result:
+                continue  # available (already live) or already placed
+            anchor = next(
+                (stored[j] for j in range(index + 1, len(stored)) if stored[j] in live_set),
+                None,
+            )
+            if anchor in result:
+                result.insert(result.index(anchor), path)
+            else:
+                result.append(path)
+        return result
+
+    def write_back_active_set(self, snapshot=None, *, authoritative=False) -> None:
         """Boundary write: persist the live selection to the active preset's set.
 
         Applies copy-on-write when the current set is shared, creates a set on
         first write, GCs orphans, and persists. A no-op when there is no real
         active preset or when nothing changed.
+
+        With an explicit *snapshot* the caller supplies the files/folders to
+        store instead of the live selection; *authoritative* then skips the
+        offline-preserving merge so the stored set becomes exactly *snapshot*.
+        Used after the user curates the full set (including missing entries) in
+        Manage Order, so a removal there actually sticks.
         """
         if getattr(self, "_loading", False):
             return
@@ -196,24 +256,30 @@ class MainAppSelectionSetsMixin:
         if not name or name not in self.presets:
             return
 
-        snapshot = self._selection_snapshot()
+        if snapshot is None:
+            snapshot = self._selection_snapshot()
         preset = self._wrapped_preset(name)
         existing_id = preset.get("selection_id")
 
         if existing_id and existing_id in self.selection_sets:
             stored = self.selection_sets[existing_id]
-            # Preserve entries missing only because their drive/tree is
-            # disconnected; never let an offline drive prune the stored set.
-            merged = self._merge_unavailable(snapshot, stored)
-            if merged == stored:
+            if authoritative:
+                # Caller curated the full set (e.g. via Manage Order); store it
+                # verbatim so removals are honored.
+                new_data = snapshot
+            else:
+                # Preserve entries missing only because their drive/tree is
+                # disconnected; never let an offline drive prune the stored set.
+                new_data = self._merge_unavailable(snapshot, stored)
+            if new_data == stored:
                 return  # no real change
             if self._set_refcount(existing_id) > 1:
                 # shared + changed -> fork a new set for this preset
                 new_id = self._new_set_id()
-                self.selection_sets[new_id] = merged
+                self.selection_sets[new_id] = new_data
                 preset["selection_id"] = new_id
             else:
-                self.selection_sets[existing_id] = merged
+                self.selection_sets[existing_id] = new_data
         else:
             # No link yet: only worth remembering if there is something to store.
             if not snapshot["files"] and not snapshot["folders"]:

--- a/src/gesturesesh/app/session.py
+++ b/src/gesturesesh/app/session.py
@@ -39,6 +39,8 @@ class MainAppSessionMixin:
 
         self.save(wait_status=False)
 
+        self.write_back_active_set()
+
         ordered_files = effective_selection_order(
             self.selection["files"], randomize=self.randomize_selection.isChecked()
         )

--- a/src/gesturesesh/main.py
+++ b/src/gesturesesh/main.py
@@ -20,12 +20,13 @@ if str(src_dir) not in sys.path:
 
 from gesturesesh.app.presets import MainAppPresetsMixin
 from gesturesesh.app.selection import MainAppSelectionMixin
+from gesturesesh.app.selection_sets import MainAppSelectionSetsMixin
 from gesturesesh.app.session import MainAppSessionMixin
 from gesturesesh.app.status import MainAppStatusMixin
 from gesturesesh.session.constants import SUPPORTED_IMAGE_TYPES
 from gesturesesh.ui.main_window import Ui_MainWindow
 from gesturesesh.utils import resources_config  # noqa: F401
-from gesturesesh.utils.config import load_config
+from gesturesesh.utils.config import get_config_dir, load_config
 from gesturesesh.utils.update_checker import UpdateChecker
 
 
@@ -34,6 +35,7 @@ __version__ = "0.5.6"
 
 class MainApp(
     MainAppSelectionMixin,
+    MainAppSelectionSetsMixin,
     MainAppStatusMixin,
     MainAppPresetsMixin,
     MainAppSessionMixin,
@@ -45,10 +47,16 @@ class MainApp(
         self.setupUi(self)
         self.setWindowTitle("Reference Practice")
         self.config = load_config(self)
+        # Resolve the config path up front so saves don't depend on
+        # check_version() (which sets it later) having run first.
+        self.config_path = get_config_dir() / "config.json"
         self.session_schedule = []
         self.has_break = False
         self.valid_file_types = set(SUPPORTED_IMAGE_TYPES)
         self.selection = {"files": [], "folders": []}
+        # Re-entrancy guard for programmatic preset/selection changes so they
+        # don't trigger selection-set writes (see selection_sets.py).
+        self._loading = False
 
         self.status_timer = QtCore.QTimer()
         self.status_timer.setSingleShot(True)
@@ -69,6 +77,7 @@ class MainApp(
         self.init_buttons()
         self.init_shortcuts()
         self.init_preset()
+        self.init_selection_sets()
         self.load_recent()
         self.check_version()
         self.entry_table.itemChanged.connect(self.update_total)
@@ -78,6 +87,14 @@ class MainApp(
     def resizeEvent(self, event):
         super().resizeEvent(event)
         self.update_dynamic_fonts()
+
+    def closeEvent(self, event):
+        # Boundary write: persist the active preset's image set on app close.
+        try:
+            self.write_back_active_set()
+        except Exception:
+            pass
+        super().closeEvent(event)
 
     def update_dynamic_fonts(self):
         """Dynamically update font sizes based on window height."""
@@ -151,6 +168,11 @@ class MainApp(
         self.delete_preset.clicked.connect(self.delete)
         self.preset_loader_box.currentIndexChanged.connect(self.load)
         self.preset_loader_box.currentTextChanged.connect(self.load)
+        # Deliberate user preset switches drive selection-set read/write.
+        # `activated` fires only on real user selection, not programmatic
+        # index changes or typing, which keeps set logic off the re-entrant
+        # currentIndexChanged/currentTextChanged path.
+        self.preset_loader_box.activated.connect(self.on_preset_switch)
         # Buttons for table
         self.remove_entry.pressed.connect(self.remove_row)
         self.move_entry_up.clicked.connect(self.move_up)

--- a/src/gesturesesh/main.py
+++ b/src/gesturesesh/main.py
@@ -166,18 +166,33 @@ class MainApp(
         self.add_entry.clicked.connect(self.append_schedule)
         self.save_preset.clicked.connect(self.save)
         self.delete_preset.clicked.connect(self.delete)
-        self.preset_loader_box.currentIndexChanged.connect(self.load)
-        self.preset_loader_box.currentTextChanged.connect(self.load)
-        # Deliberate user preset switches drive selection-set read/write.
-        # `activated` fires only on real user selection, not programmatic
-        # index changes or typing, which keeps set logic off the re-entrant
-        # currentIndexChanged/currentTextChanged path.
-        self.preset_loader_box.activated.connect(self.on_preset_switch)
+        self._connect_preset_loader_signals()
         # Buttons for table
         self.remove_entry.pressed.connect(self.remove_row)
         self.move_entry_up.clicked.connect(self.move_up)
         self.move_entry_down.clicked.connect(self.move_down)
         self.reset_table.clicked.connect(self.remove_rows)
+
+    def _connect_preset_loader_signals(self):
+        """Wire the preset combo's signals.
+
+        Schedule loading follows index/text changes. The selection-set
+        read/write stays on the *deliberate-switch* triggers so it never runs on
+        the re-entrant ``currentIndexChanged``/``currentTextChanged`` path:
+
+        * ``activated`` – the user picks an entry from the dropdown.
+        * the line edit's ``editingFinished`` – the user types an existing preset
+          name and commits it (Enter / focus-out). ``activated`` does not fire
+          for typing, so without this a typed switch would load the new schedule
+          while the image set stayed on the previously active preset (and a
+          following save/start could persist the old images onto it).
+        """
+        self.preset_loader_box.currentIndexChanged.connect(self.load)
+        self.preset_loader_box.currentTextChanged.connect(self.load)
+        self.preset_loader_box.activated.connect(self.on_preset_switch)
+        line_edit = self.preset_loader_box.lineEdit()
+        if line_edit is not None:
+            line_edit.editingFinished.connect(self.on_preset_switch)
 
     def init_shortcuts(self):
         # Ctrl+Enter to start session

--- a/src/gesturesesh/main.py
+++ b/src/gesturesesh/main.py
@@ -29,7 +29,7 @@ from gesturesesh.utils.config import load_config
 from gesturesesh.utils.update_checker import UpdateChecker
 
 
-__version__ = "0.5.5"
+__version__ = "0.5.6"
 
 
 class MainApp(

--- a/src/gesturesesh/session/constants.py
+++ b/src/gesturesesh/session/constants.py
@@ -5,6 +5,7 @@ Lives in its own module so submodules (timer, etc.) and the parent
 """
 
 import contextlib
+import os
 from importlib import resources
 from pathlib import Path
 
@@ -23,6 +24,20 @@ SUPPORTED_IMAGE_TYPES = {
 }
 
 SUPPORTED_ANIMATED_TYPES = {".avif", ".gif", ".jxl", ".webp"}
+
+
+def is_hidden_file(path) -> bool:
+    """Return True for hidden/sidecar files that should not be treated as images.
+
+    Matches any dotfile (basename starting with ``.``). The important case is the
+    macOS AppleDouble sidecar ``._name.ext``: it mirrors a real file's extension
+    (so an extension check alone accepts it) but holds resource-fork metadata
+    rather than image data. These are generated when files are copied to
+    FAT/exFAT/SMB/USB volumes and, if added to the playlist, fail to decode at
+    display time. Other dotfiles (``.DS_Store``, ``.thumbnails``, etc.) are OS
+    noise too, so we skip the whole class.
+    """
+    return os.path.basename(str(path)).startswith(".")
 
 
 def sound_file(name: str):

--- a/src/gesturesesh/session/image_loader.py
+++ b/src/gesturesesh/session/image_loader.py
@@ -295,9 +295,45 @@ class SessionImageLoaderMixin:
             else:
                 with open(image_path, "rb") as f:
                     file_bytes = np.asarray(bytearray(f.read()), dtype=np.uint8)
-            return cv2.imdecode(file_bytes, cv2.IMREAD_UNCHANGED)
+            cvimage = cv2.imdecode(file_bytes, cv2.IMREAD_UNCHANGED)
+            return self._apply_exif_orientation(cvimage, image_path)
         except Exception:
             return None
+
+    def _apply_exif_orientation(self, cvimage, image_path):
+        """Rotate/flip a cv2-decoded array to honor the source's EXIF orientation.
+
+        ``cv2.imdecode(..., IMREAD_UNCHANGED)`` deliberately ignores the EXIF
+        orientation tag (unlike ``IMREAD_COLOR``), so photos shot on phones and
+        cameras would display rotated. We read just the orientation tag via
+        Pillow (no pixel decode) and apply the matching transform, preserving the
+        alpha channel and bit depth that ``IMREAD_UNCHANGED`` gives us. The
+        transforms mirror ``PIL.ImageOps.exif_transpose`` so still images match
+        the Selection Order Viewer thumbnails.
+        """
+        if cvimage is None or Image is None or image_path.startswith(":/"):
+            return cvimage
+        try:
+            with Image.open(image_path) as pil_image:
+                orientation = int(pil_image.getexif().get(0x0112, 1) or 1)
+        except Exception:
+            return cvimage
+
+        if orientation == 2:  # mirror horizontal
+            return cv2.flip(cvimage, 1)
+        if orientation == 3:  # rotate 180
+            return cv2.rotate(cvimage, cv2.ROTATE_180)
+        if orientation == 4:  # mirror vertical
+            return cv2.flip(cvimage, 0)
+        if orientation == 5:  # mirror along the main diagonal (transpose)
+            return cv2.transpose(cvimage)
+        if orientation == 6:  # rotate 90 clockwise
+            return cv2.rotate(cvimage, cv2.ROTATE_90_CLOCKWISE)
+        if orientation == 7:  # mirror along the anti-diagonal (transverse)
+            return cv2.rotate(cv2.transpose(cvimage), cv2.ROTATE_180)
+        if orientation == 8:  # rotate 90 counterclockwise
+            return cv2.rotate(cvimage, cv2.ROTATE_90_COUNTERCLOCKWISE)
+        return cvimage
 
     def decode_with_pillow(self, image_path):
         if Image is None or image_path.startswith(":/"):

--- a/src/gesturesesh/session_window.py
+++ b/src/gesturesesh/session_window.py
@@ -6,7 +6,6 @@ import math
 import random
 import sys
 from collections import OrderedDict
-from pathlib import Path
 
 from pygame import mixer
 

--- a/src/gesturesesh/session_window.py
+++ b/src/gesturesesh/session_window.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import math
-import platform
 import random
 import sys
 from collections import OrderedDict
@@ -30,6 +29,7 @@ from gesturesesh.session.shortcuts import SessionShortcutsMixin
 from gesturesesh.session.timer import SessionTimerMixin
 from gesturesesh.session.zoom_pan import SessionZoomPanMixin
 from gesturesesh.utils import resources_config  # noqa: F401
+from gesturesesh.utils.file_reveal import reveal_in_file_manager
 from gesturesesh.ui.dialogs import (
     run_selection_order_dialog,
     run_shortcut_map_dialog,
@@ -1255,19 +1255,7 @@ class SessionDisplay(
 
     def open_image_directory(self, event=None):
         path = self.playlist[self.playlist_position]
-        if path.startswith(":/"):
-            return
-        resolved_path = str(Path(path).resolve())
-        system = platform.system()
-        if system == "Windows":
-            QtCore.QProcess.startDetached("explorer.exe", [f"/select,", resolved_path])
-        elif system == "Darwin":  # macOS
-            QtCore.QProcess.startDetached("open", ["-R", resolved_path])
-        else:  # Linux and other systems
-            # Use xdg-open for Linux
-            parent_dir = Path(resolved_path).parent
-            QtCore.QProcess.startDetached("xdg-open", [str(parent_dir)])
-        if event:
+        if reveal_in_file_manager(path) and event:
             event.accept()
 
     # endregion

--- a/src/gesturesesh/ui/dialogs.py
+++ b/src/gesturesesh/ui/dialogs.py
@@ -25,6 +25,7 @@ from gesturesesh.app.selection_order import (
     selection_stats,
 )
 from gesturesesh.session.constants import is_hidden_file
+from gesturesesh.utils.file_reveal import reveal_in_file_manager
 
 
 class OrderListWidget(QtWidgets.QListWidget):
@@ -55,6 +56,7 @@ class ImageManagerDialog(QtWidgets.QDialog):
         validate_files=None,
         title="Selection Order",
         random_preview=False,
+        focus_missing=False,
     ):
         super().__init__(parent)
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose, True)
@@ -71,6 +73,7 @@ class ImageManagerDialog(QtWidgets.QDialog):
         self._current_index = current_index
         self._validate_files = validate_files
         self.random_preview = bool(random_preview)
+        self._focus_missing = bool(focus_missing)
         self.working_files = list(files)
         self.working_folders = list(folders or [])
         self._thumbnail_cache = {}
@@ -154,6 +157,13 @@ class ImageManagerDialog(QtWidgets.QDialog):
         self.add_folder_btn = QtWidgets.QPushButton("Add Folder", self)
         self.remove_selected_btn = QtWidgets.QPushButton("Remove Selected", self)
         self.remove_missing_btn = QtWidgets.QPushButton("Remove Missing", self)
+        self.show_missing_btn = QtWidgets.QPushButton("Show Missing", self)
+        self.show_missing_btn.setCheckable(True)
+        self.show_missing_btn.setToolTip("Show only files that are missing from disk.")
+        if self._focus_missing:
+            # Opened to review missing files: start filtered to just those.
+            self.show_missing_btn.setChecked(True)
+            self.show_missing_btn.setText("Show All")
         self.show_duplicates_btn = QtWidgets.QPushButton("Show Duplicates", self)
         self.show_duplicates_btn.setCheckable(True)
         self.move_up_btn = QtWidgets.QPushButton("Move Up", self)
@@ -164,6 +174,9 @@ class ImageManagerDialog(QtWidgets.QDialog):
         self.sort_name_btn = QtWidgets.QPushButton("Sort Name", self)
         self.sort_path_btn = QtWidgets.QPushButton("Sort Path", self)
         self.open_folder_btn = QtWidgets.QPushButton("Open Folder", self)
+        self.open_folder_btn.setToolTip(
+            "Reveal the highlighted image in your file browser, selecting it."
+        )
         self.clear_all_btn = QtWidgets.QPushButton("Clear All", self)
 
         for widget in (
@@ -171,6 +184,7 @@ class ImageManagerDialog(QtWidgets.QDialog):
             self.add_folder_btn,
             self.remove_selected_btn,
             self.remove_missing_btn,
+            self.show_missing_btn,
             self.show_duplicates_btn,
             self.move_up_btn,
             self.move_down_btn,
@@ -197,6 +211,7 @@ class ImageManagerDialog(QtWidgets.QDialog):
         self.add_folder_btn.clicked.connect(self._add_folder)
         self.remove_selected_btn.clicked.connect(self._remove_selected)
         self.remove_missing_btn.clicked.connect(self._remove_missing)
+        self.show_missing_btn.toggled.connect(self._toggle_show_missing)
         self.show_duplicates_btn.toggled.connect(self._toggle_show_duplicates)
         self.move_up_btn.clicked.connect(lambda: self._move_selected(-1))
         self.move_down_btn.clicked.connect(lambda: self._move_selected(1))
@@ -408,13 +423,14 @@ class ImageManagerDialog(QtWidgets.QDialog):
         self._pending_thumbnail_keys = set()
         self._thumbnail_generation += 1
         query = self.search_input.text().strip().lower()
+        show_missing_only = self.show_missing_btn.isChecked()
         self.images_list.clear()
         has_locked_rows = any(
             self._is_locked_index(index) for index in range(len(self.working_files))
         )
         self.images_list.setDragDropMode(
             QtWidgets.QAbstractItemView.NoDragDrop
-            if query or has_locked_rows
+            if query or has_locked_rows or show_missing_only
             else QtWidgets.QAbstractItemView.InternalMove
         )
         visible = 0
@@ -433,11 +449,14 @@ class ImageManagerDialog(QtWidgets.QDialog):
                 continue
 
             is_break = file_path == BREAK_IMAGE_PATH
+            if not is_break:
+                real_seen += 1
+            is_missing = not is_break and not os.path.exists(file_path)
+            if show_missing_only and not is_missing:
+                continue
             is_duplicate = index in duplicate_indices
             is_locked = self._is_locked_index(index)
             is_current = self._current_index == index
-            if not is_break:
-                real_seen += 1
 
             markers = []
             if is_break:
@@ -450,7 +469,7 @@ class ImageManagerDialog(QtWidgets.QDialog):
                 markers.append("LOCKED")
             if show_duplicates and is_duplicate:
                 markers.append("DUPLICATE")
-            if file_path != BREAK_IMAGE_PATH and not os.path.exists(file_path):
+            if is_missing:
                 markers.append("MISSING")
 
             display_name = "Break" if is_break else os.path.basename(file_path)
@@ -463,7 +482,7 @@ class ImageManagerDialog(QtWidgets.QDialog):
 
             if is_locked:
                 item.setForeground(QtGui.QBrush(QtGui.QColor("#b8c4cc")))
-            if file_path != BREAK_IMAGE_PATH and not os.path.exists(file_path):
+            if is_missing:
                 item.setForeground(QtGui.QBrush(QtGui.QColor("#ff7f7f")))
             elif show_duplicates and is_duplicate:
                 item.setBackground(QtGui.QBrush(QtGui.QColor("#40361e")))
@@ -589,7 +608,15 @@ class ImageManagerDialog(QtWidgets.QDialog):
             for index, path in enumerate(self.working_files)
             if self._is_locked_index(index) or path == BREAK_IMAGE_PATH or os.path.exists(path)
         ]
-        self._refresh_list()
+        # If we were filtered to missing-only and nothing missing remains, drop
+        # the filter so the user isn't left looking at an empty list.
+        still_missing = any(
+            p != BREAK_IMAGE_PATH and not os.path.exists(p) for p in self.working_files
+        )
+        if self.show_missing_btn.isChecked() and not still_missing:
+            self.show_missing_btn.setChecked(False)  # triggers refresh via toggled
+        else:
+            self._refresh_list()
 
     def _move_selected(self, direction):
         indices = self._selected_indices()
@@ -668,16 +695,19 @@ class ImageManagerDialog(QtWidgets.QDialog):
             return
 
         target = self.working_files[indices[0]]
-        folder = os.path.dirname(target)
-        if folder and os.path.isdir(folder):
-            QtGui.QDesktopServices.openUrl(
-                QtCore.QUrl.fromLocalFile(os.path.abspath(folder))
-            )
+        if target and target != BREAK_IMAGE_PATH:
+            # Reveal-and-select the highlighted image so it's easy to spot,
+            # mirroring the session window's "open folder" behavior.
+            reveal_in_file_manager(target)
 
     def _clear_all(self):
         self.working_files = [
             path for index, path in enumerate(self.working_files) if self._is_locked_index(index)
         ]
+        self._refresh_list()
+
+    def _toggle_show_missing(self, checked):
+        self.show_missing_btn.setText("Show All" if checked else "Show Missing")
         self._refresh_list()
 
     def _toggle_show_duplicates(self, checked):

--- a/src/gesturesesh/ui/dialogs.py
+++ b/src/gesturesesh/ui/dialogs.py
@@ -24,6 +24,7 @@ from gesturesesh.app.selection_order import (
     duplicate_indices,
     selection_stats,
 )
+from gesturesesh.session.constants import is_hidden_file
 
 
 class OrderListWidget(QtWidgets.QListWidget):
@@ -543,6 +544,10 @@ class ImageManagerDialog(QtWidgets.QDialog):
     def _check_files(self, files):
         valid = []
         for file_path in files:
+            # Skip hidden dotfiles / macOS AppleDouble sidecars (._name.ext);
+            # they share a real image's extension but aren't decodable images.
+            if is_hidden_file(file_path):
+                continue
             ext = os.path.splitext(file_path)[1].lower()
             if self._valid_file_types and ext not in self._valid_file_types:
                 continue

--- a/src/gesturesesh/utils/file_reveal.py
+++ b/src/gesturesesh/utils/file_reveal.py
@@ -1,0 +1,51 @@
+"""Reveal a file in the OS file manager, highlighting it when possible.
+
+Shared by the session window and the Manage Order dialog so their
+"open folder" actions land on — and select — the specific image the user is
+looking at, instead of merely opening its containing directory.
+"""
+
+from __future__ import annotations
+
+import platform
+from pathlib import Path
+
+from PyQt5 import QtCore
+
+
+def reveal_in_file_manager(path: str) -> bool:
+    """Open the OS file manager with *path* highlighted.
+
+    On Windows and macOS the file itself is selected; Linux has no portable
+    "select" flag, so the containing folder is opened instead. If the file is
+    gone, fall back to opening its parent directory so the user still lands
+    nearby. Qt resource paths (``:/...``) and empty paths are ignored.
+
+    Returns ``True`` when a command was dispatched, ``False`` otherwise.
+    """
+    if not path or path.startswith(":/"):
+        return False
+
+    resolved = Path(path).resolve()
+    system = platform.system()
+
+    if resolved.exists():
+        if system == "Windows":
+            QtCore.QProcess.startDetached("explorer.exe", ["/select,", str(resolved)])
+        elif system == "Darwin":
+            QtCore.QProcess.startDetached("open", ["-R", str(resolved)])
+        else:  # Linux and other systems: no universal reveal-and-select.
+            QtCore.QProcess.startDetached("xdg-open", [str(resolved.parent)])
+        return True
+
+    # The file no longer exists; open its folder if that still does.
+    parent = resolved.parent
+    if not parent.is_dir():
+        return False
+    if system == "Windows":
+        QtCore.QProcess.startDetached("explorer.exe", [str(parent)])
+    elif system == "Darwin":
+        QtCore.QProcess.startDetached("open", [str(parent)])
+    else:
+        QtCore.QProcess.startDetached("xdg-open", [str(parent)])
+    return True

--- a/tests/test_file_reveal.py
+++ b/tests/test_file_reveal.py
@@ -1,0 +1,85 @@
+"""Tests for reveal_in_file_manager (utils/file_reveal.py)."""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
+
+from gesturesesh.utils.file_reveal import reveal_in_file_manager
+
+
+class TestRevealInFileManager(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.file = os.path.join(self.tmp, "img.png")
+        with open(self.file, "w") as f:
+            f.write("x")
+        self.resolved = str(Path(self.file).resolve())
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _patches(self, system):
+        return (
+            patch("gesturesesh.utils.file_reveal.platform.system", lambda: system),
+            patch("gesturesesh.utils.file_reveal.QtCore.QProcess.startDetached"),
+        )
+
+    def test_windows_selects_file(self):
+        sys_patch, start_patch = self._patches("Windows")
+        with sys_patch, start_patch as mock_start:
+            self.assertTrue(reveal_in_file_manager(self.file))
+            mock_start.assert_called_once_with(
+                "explorer.exe", ["/select,", self.resolved]
+            )
+
+    def test_macos_reveals_file(self):
+        sys_patch, start_patch = self._patches("Darwin")
+        with sys_patch, start_patch as mock_start:
+            self.assertTrue(reveal_in_file_manager(self.file))
+            mock_start.assert_called_once_with("open", ["-R", self.resolved])
+
+    def test_linux_opens_parent(self):
+        sys_patch, start_patch = self._patches("Linux")
+        with sys_patch, start_patch as mock_start:
+            self.assertTrue(reveal_in_file_manager(self.file))
+            mock_start.assert_called_once_with(
+                "xdg-open", [str(Path(self.resolved).parent)]
+            )
+
+    def test_resource_path_ignored(self):
+        sys_patch, start_patch = self._patches("Darwin")
+        with sys_patch, start_patch as mock_start:
+            self.assertFalse(reveal_in_file_manager(":/break.png"))
+            mock_start.assert_not_called()
+
+    def test_empty_path_ignored(self):
+        sys_patch, start_patch = self._patches("Darwin")
+        with sys_patch, start_patch as mock_start:
+            self.assertFalse(reveal_in_file_manager(""))
+            mock_start.assert_not_called()
+
+    def test_missing_file_falls_back_to_folder(self):
+        missing = os.path.join(self.tmp, "gone.png")
+        sys_patch, start_patch = self._patches("Darwin")
+        with sys_patch, start_patch as mock_start:
+            self.assertTrue(reveal_in_file_manager(missing))
+            mock_start.assert_called_once_with(
+                "open", [str(Path(missing).resolve().parent)]
+            )
+
+    def test_missing_file_and_folder_returns_false(self):
+        missing = os.path.join(self.tmp, "nope", "gone.png")
+        sys_patch, start_patch = self._patches("Darwin")
+        with sys_patch, start_patch as mock_start:
+            self.assertFalse(reveal_in_file_manager(missing))
+            mock_start.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hidden_files.py
+++ b/tests/test_hidden_files.py
@@ -1,0 +1,82 @@
+"""Hidden dotfiles and macOS AppleDouble sidecars (``._name.ext``) must never be
+treated as images: they share a real file's extension but hold metadata, so they
+would be added to the playlist and then fail to decode at display time."""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src")
+)
+
+from gesturesesh.app.selection import MainAppSelectionMixin
+from gesturesesh.session.constants import is_hidden_file
+
+
+class TestIsHiddenFile(unittest.TestCase):
+    def test_appledouble_and_dotfiles_are_hidden(self):
+        for path in (
+            "/photos/._image1.jpg",
+            "._image1.jpg",
+            "/photos/.DS_Store",
+            "/photos/.hidden.png",
+        ):
+            self.assertTrue(is_hidden_file(path), path)
+
+    def test_normal_files_are_not_hidden(self):
+        for path in (
+            "/photos/image1.jpg",
+            "image1.jpg",
+            "/photos/my._weird.jpg",  # only a leading "._" basename counts
+            "/a.dotted.dir/image.png",
+        ):
+            self.assertFalse(is_hidden_file(path), path)
+
+
+class TestCheckFilesSkipsHidden(unittest.TestCase):
+    """Exercises the real ``MainAppSelectionMixin.check_files``."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        self.fake = types.SimpleNamespace(
+            valid_file_types={".jpg", ".jpeg", ".png", ".bmp"}
+        )
+
+    def _make(self, name):
+        path = os.path.join(self.tmp, name)
+        Path(path).touch()
+        return path
+
+    def test_appledouble_excluded_silently(self):
+        real = self._make("image1.jpg")
+        sidecar = self._make("._image1.jpg")
+        ds_store = self._make(".DS_Store")
+
+        result = MainAppSelectionMixin.check_files(
+            self.fake, [real, sidecar, ds_store]
+        )
+
+        self.assertEqual(result["valid_files"], [real])
+        # Hidden files are skipped silently, not reported as "unsupported".
+        self.assertEqual(result["invalid_files"], [])
+
+    def test_unsupported_extension_still_reported(self):
+        real = self._make("image1.jpg")
+        doc = self._make("notes.txt")
+
+        result = MainAppSelectionMixin.check_files(self.fake, [real, doc])
+
+        self.assertEqual(result["valid_files"], [real])
+        self.assertEqual(result["invalid_files"], [doc])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scan_directories.py
+++ b/tests/test_scan_directories.py
@@ -21,17 +21,24 @@ from pathlib import Path
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'src'))
 
 from gesturesesh.main import MainApp
+from gesturesesh.session.constants import is_hidden_file
 
 class TestableMainApp:
     """Lightweight testable version of MainApp for testing scan_directories"""
     def __init__(self):
         self.valid_file_types = {".bmp", ".jpg", ".jpeg", ".png"}
         self.selection = {"files": [], "folders": []}
-    
+
     def check_files(self, files):
-        """Checks if files are supported file types and are accessible."""
+        """Checks if files are supported file types and are accessible.
+
+        Mirrors ``MainAppSelectionMixin.check_files``: hidden dotfiles and macOS
+        AppleDouble sidecars (._name.ext) are skipped silently.
+        """
         res = {"valid_files": [], "invalid_files": []}
         for file in files:
+            if is_hidden_file(file):
+                continue
             ext = os.path.splitext(file)[1].lower()
             if ext not in self.valid_file_types:
                 res["invalid_files"].append(file)
@@ -216,6 +223,24 @@ class TestScanDirectories(unittest.TestCase):
         self.assertIsInstance(valid, int)
         self.assertIsInstance(invalid, int)
         
+    def test_appledouble_sidecars_are_skipped(self):
+        """macOS AppleDouble sidecars (._name.jpg) in a scanned folder must not
+        be added to the selection or counted as invalid."""
+        # These appear alongside real files on FAT/exFAT/SMB/USB volumes.
+        for name in ("._image1.jpg", "._sub_image1.jpeg", ".DS_Store"):
+            Path(os.path.join(self.test_dir, name)).touch()
+        Path(os.path.join(self.sub_dir, "._sub_image2.png")).touch()
+
+        self.app.selection = {"files": [], "folders": []}
+        valid, invalid = self.app.scan_directories([self.test_dir])
+
+        # Same totals as the clean tree: 5 valid, 2 invalid (txt + mp4).
+        self.assertEqual(valid, 5)
+        self.assertEqual(invalid, 2)
+        selected_basenames = [os.path.basename(f) for f in self.app.selection["files"]]
+        self.assertNotIn("._image1.jpg", selected_basenames)
+        self.assertFalse(any(name.startswith("._") for name in selected_basenames))
+
     def test_case_insensitive_extensions(self):
         """Test that file extensions are handled case-insensitively"""
         # Create files with uppercase extensions

--- a/tests/test_selection_sets.py
+++ b/tests/test_selection_sets.py
@@ -1,0 +1,293 @@
+"""Tests for per-preset image-set associations (selection_sets.py)."""
+
+import os
+import sys
+import types
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from PyQt5 import QtWidgets
+from PyQt5.QtWidgets import QApplication
+
+app = QApplication.instance()
+if app is None:
+    app = QApplication(sys.argv)
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
+
+from gesturesesh.main import MainApp
+from gesturesesh.ui.main_window import Ui_MainWindow
+
+
+def _mock_setup_ui(self, main_window):
+    """Minimal widget stubbing so MainApp() constructs without a real UI."""
+    self.selected_items = MagicMock(spec=QtWidgets.QTextEdit)
+    self.preset_loader_box = MagicMock(spec=QtWidgets.QComboBox)
+    self.entry_table = MagicMock(spec=QtWidgets.QTableWidget)
+    self.total_table = MagicMock(spec=QtWidgets.QTableWidget)
+    self.randomize_selection = MagicMock(spec=QtWidgets.QPushButton)
+    self.set_number_of_images = MagicMock(spec=QtWidgets.QSpinBox)
+    self.set_minutes = MagicMock(spec=QtWidgets.QSpinBox)
+    self.set_seconds = MagicMock(spec=QtWidgets.QSpinBox)
+    self.dialog_buttons = MagicMock(spec=QtWidgets.QDialogButtonBox)
+
+
+class TestSelectionSets(unittest.TestCase):
+    def setUp(self):
+        self._patchers = [
+            patch.object(Ui_MainWindow, "setupUi", _mock_setup_ui),
+            patch("gesturesesh.main.MainApp.check_version", lambda s: None),
+            patch("gesturesesh.main.MainApp.load_recent", lambda s: None),
+            patch("gesturesesh.main.MainApp.init_preset", lambda s: None),
+            patch("gesturesesh.main.MainApp.init_shortcuts", lambda s: None),
+            patch("gesturesesh.main.MainApp.init_buttons", lambda s: None),
+            patch("gesturesesh.main.MainApp.update_dynamic_fonts", lambda s: None),
+        ]
+        for p in self._patchers:
+            p.start()
+
+        self.test_dir = tempfile.mkdtemp()
+        self.app = MainApp()
+
+        # Isolate from the real on-disk config and any pre-existing state.
+        self.app.config = {}
+        self.app.config_path = Path(self.test_dir) / "config.json"
+        self.app.presets = {}
+        self.app.selection_sets = {}
+        self.app._active_set_preset = None
+        self.app._loading = False
+        self.app.selection = {"files": [], "folders": []}
+        # Keep status/UI side effects out of the logic under test.
+        self.app.show_temporary_status = types.MethodType(
+            lambda s, *a, **k: None, self.app
+        )
+        self.app.display_status = types.MethodType(lambda s: None, self.app)
+
+    def tearDown(self):
+        for p in self._patchers:
+            p.stop()
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def _touch(self, name):
+        path = os.path.join(self.test_dir, name)
+        with open(path, "w") as f:
+            f.write("x")
+        return path
+
+    # -- write-back / creation -------------------------------------------------
+
+    def test_first_write_creates_and_links_set(self):
+        self.app.presets = {"A": {"schedule": {}}}
+        self.app._active_set_preset = "A"
+        self.app.selection = {"files": ["/x.png"], "folders": ["/imgs"]}
+
+        self.app.write_back_active_set()
+
+        set_id = self.app.presets["A"].get("selection_id")
+        self.assertIsNotNone(set_id)
+        self.assertEqual(
+            self.app.selection_sets[set_id],
+            {"files": ["/x.png"], "folders": ["/imgs"]},
+        )
+
+    def test_empty_selection_creates_no_link(self):
+        self.app.presets = {"A": {"schedule": {}}}
+        self.app._active_set_preset = "A"
+        self.app.selection = {"files": [], "folders": []}
+
+        self.app.write_back_active_set()
+
+        self.assertNotIn("selection_id", self.app.presets["A"])
+        self.assertEqual(self.app.selection_sets, {})
+
+    def test_write_back_noop_when_unchanged(self):
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
+        self.app.selection_sets = {"set1": {"files": ["/x.png"], "folders": []}}
+        self.app._active_set_preset = "A"
+        self.app.selection = {"files": ["/x.png"], "folders": []}
+
+        self.app.write_back_active_set()
+
+        self.assertEqual(self.app.presets["A"]["selection_id"], "set1")
+        self.assertEqual(list(self.app.selection_sets.keys()), ["set1"])
+
+    def test_unshared_set_updated_in_place(self):
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
+        self.app.selection_sets = {"set1": {"files": ["/x.png"], "folders": []}}
+        self.app._active_set_preset = "A"
+        self.app.selection = {"files": ["/x.png", "/y.png"], "folders": []}
+
+        self.app.write_back_active_set()
+
+        self.assertEqual(self.app.presets["A"]["selection_id"], "set1")
+        self.assertEqual(
+            self.app.selection_sets["set1"],
+            {"files": ["/x.png", "/y.png"], "folders": []},
+        )
+
+    def test_shared_set_edit_forks_copy_on_write(self):
+        self.app.presets = {
+            "A": {"schedule": {}, "selection_id": "set1"},
+            "B": {"schedule": {}, "selection_id": "set1"},
+        }
+        self.app.selection_sets = {"set1": {"files": ["/x.png"], "folders": []}}
+        self.app._active_set_preset = "B"
+        self.app.selection = {"files": ["/x.png", "/y.png"], "folders": []}
+
+        self.app.write_back_active_set()
+
+        # A keeps the original set untouched; B gets a fresh forked set.
+        self.assertEqual(self.app.presets["A"]["selection_id"], "set1")
+        self.assertEqual(self.app.selection_sets["set1"], {"files": ["/x.png"], "folders": []})
+        new_id = self.app.presets["B"]["selection_id"]
+        self.assertNotEqual(new_id, "set1")
+        self.assertEqual(
+            self.app.selection_sets[new_id],
+            {"files": ["/x.png", "/y.png"], "folders": []},
+        )
+
+    def test_loading_guard_suppresses_write(self):
+        self.app.presets = {"A": {"schedule": {}}}
+        self.app._active_set_preset = "A"
+        self.app.selection = {"files": ["/x.png"], "folders": []}
+        self.app._loading = True
+
+        self.app.write_back_active_set()
+
+        self.assertNotIn("selection_id", self.app.presets["A"])
+        self.assertEqual(self.app.selection_sets, {})
+
+    # -- external-drive / offline safety --------------------------------------
+
+    def test_offline_set_preserved_when_no_edits(self):
+        # Paths under a directory that does not exist (simulates an unplugged
+        # drive: the whole mount point is gone).
+        offline = [
+            "/Volumes/NopeDriveXYZ/refs/a.png",
+            "/Volumes/NopeDriveXYZ/refs/b.png",
+        ]
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
+        self.app.selection_sets = {
+            "set1": {"files": list(offline), "folders": ["/Volumes/NopeDriveXYZ/refs"]}
+        }
+        self.app._active_set_preset = "A"
+        # apply() while offline would leave the working selection empty.
+        self.app.selection = {"files": [], "folders": []}
+
+        self.app.write_back_active_set()
+
+        self.assertEqual(self.app.selection_sets["set1"]["files"], offline)
+
+    def test_offline_files_preserved_when_adding_local_file(self):
+        offline = "/Volumes/NopeDriveXYZ/refs/a.png"
+        local = self._touch("local.png")
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
+        self.app.selection_sets = {"set1": {"files": [offline], "folders": []}}
+        self.app._active_set_preset = "A"
+        # User added a local file while the drive was disconnected.
+        self.app.selection = {"files": [local], "folders": []}
+
+        self.app.write_back_active_set()
+
+        files = self.app.selection_sets["set1"]["files"]
+        self.assertIn(local, files)
+        self.assertIn(offline, files)
+
+    def test_in_place_deleted_file_dropped_offline_kept(self):
+        # f1 exists then is removed by the user (its folder still exists ->
+        # treated as a real removal). offline file's tree is gone -> preserved.
+        f1 = self._touch("keep_then_remove.png")
+        offline = "/Volumes/NopeDriveXYZ/refs/b.png"
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
+        self.app.selection_sets = {"set1": {"files": [f1, offline], "folders": []}}
+        self.app._active_set_preset = "A"
+        # User removed f1 from the visible selection.
+        self.app.selection = {"files": [], "folders": []}
+
+        self.app.write_back_active_set()
+
+        self.assertEqual(self.app.selection_sets["set1"]["files"], [offline])
+
+    # -- garbage collection ----------------------------------------------------
+
+    def test_gc_removes_orphans_keeps_linked(self):
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
+        self.app.selection_sets = {
+            "set1": {"files": ["/x.png"], "folders": []},
+            "orphan": {"files": ["/z.png"], "folders": []},
+        }
+
+        self.app._gc_selection_sets()
+
+        self.assertIn("set1", self.app.selection_sets)
+        self.assertNotIn("orphan", self.app.selection_sets)
+
+    # -- apply / lazy validation ----------------------------------------------
+
+    def test_apply_set_drops_missing_files_preserves_order(self):
+        f1 = self._touch("a.png")
+        f2 = self._touch("b.png")
+        missing = os.path.join(self.test_dir, "gone.png")
+        self.app.selection_sets = {
+            "set1": {"files": [f1, missing, f2], "folders": [self.test_dir]}
+        }
+
+        self.app.apply_selection_set("set1")
+
+        self.assertEqual(self.app.selection["files"], [f1, f2])
+        self.assertEqual(self.app.selection["folders"], [self.test_dir])
+
+    def test_apply_missing_id_is_noop(self):
+        self.app.selection = {"files": ["/keep.png"], "folders": ["/keep"]}
+        self.app.apply_selection_set("does-not-exist")
+        self.assertEqual(self.app.selection, {"files": ["/keep.png"], "folders": ["/keep"]})
+
+    # -- switch handler --------------------------------------------------------
+
+    def test_on_preset_switch_writes_old_and_applies_new(self):
+        b1 = self._touch("b1.png")
+        self.app.presets = {
+            "A": {"schedule": {}, "selection_id": "setA"},
+            "B": {"schedule": {}, "selection_id": "setB"},
+        }
+        self.app.selection_sets = {
+            "setA": {"files": ["/old.png"], "folders": []},
+            "setB": {"files": [b1], "folders": []},
+        }
+        self.app._active_set_preset = "A"
+        # Live working copy for A diverged from setA.
+        self.app.selection = {"files": ["/a-new.png"], "folders": []}
+        self.app.preset_loader_box.currentText = lambda: "B"
+
+        self.app.on_preset_switch()
+
+        # A's set was written back from the live selection (unshared -> in place).
+        self.assertEqual(
+            self.app.selection_sets["setA"], {"files": ["/a-new.png"], "folders": []}
+        )
+        # B's set is applied to the live selection (validated).
+        self.assertEqual(self.app.selection["files"], [b1])
+        self.assertEqual(self.app._active_set_preset, "B")
+
+    def test_on_preset_switch_unlinked_target_keeps_selection(self):
+        self.app.presets = {
+            "A": {"schedule": {}, "selection_id": "setA"},
+            "B": {"schedule": {}},  # no linked set
+        }
+        self.app.selection_sets = {"setA": {"files": ["/old.png"], "folders": []}}
+        self.app._active_set_preset = "A"
+        self.app.selection = {"files": ["/keep.png"], "folders": []}
+        self.app.preset_loader_box.currentText = lambda: "B"
+
+        self.app.on_preset_switch()
+
+        # Switching to an unlinked preset leaves the current selection in place.
+        self.assertEqual(self.app.selection["files"], ["/keep.png"])
+        self.assertEqual(self.app._active_set_preset, "B")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_selection_sets.py
+++ b/tests/test_selection_sets.py
@@ -245,6 +245,229 @@ class TestSelectionSets(unittest.TestCase):
         self.app.apply_selection_set("does-not-exist")
         self.assertEqual(self.app.selection, {"files": ["/keep.png"], "folders": ["/keep"]})
 
+    # -- unavailable reporting -------------------------------------------------
+
+    def test_active_set_unavailable_lists_missing_files_and_folders(self):
+        present = self._touch("here.png")
+        gone = os.path.join(self.test_dir, "gone.png")
+        missing_dir = os.path.join(self.test_dir, "no_such_dir")
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
+        self.app.selection_sets = {
+            "set1": {"files": [present, gone], "folders": [self.test_dir, missing_dir]}
+        }
+        self.app._active_set_preset = "A"
+
+        result = self.app._active_set_unavailable()
+
+        self.assertEqual(result["files"], [gone])
+        self.assertEqual(result["folders"], [missing_dir])
+
+    def test_active_set_unavailable_empty_when_all_present(self):
+        present = self._touch("here.png")
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
+        self.app.selection_sets = {
+            "set1": {"files": [present], "folders": [self.test_dir]}
+        }
+        self.app._active_set_preset = "A"
+
+        self.assertEqual(
+            self.app._active_set_unavailable(), {"files": [], "folders": []}
+        )
+
+    def test_active_set_unavailable_empty_without_active_preset(self):
+        self.app._active_set_preset = None
+        self.assertEqual(
+            self.app._active_set_unavailable(), {"files": [], "folders": []}
+        )
+
+    def test_active_set_unavailable_empty_when_preset_has_no_link(self):
+        self.app.presets = {"A": {"schedule": {}}}  # no selection_id
+        self.app._active_set_preset = "A"
+        self.assertEqual(
+            self.app._active_set_unavailable(), {"files": [], "folders": []}
+        )
+
+    # -- authoritative write (Manage Order curation) ---------------------------
+
+    def test_authoritative_write_drops_offline_file_user_removed(self):
+        # An offline file (whole dir gone) the user removed in Manage Order must
+        # stay removed, even though the boundary merge would normally preserve it.
+        present = self._touch("keep.png")
+        offline = "/mnt/usb/gone.png"  # parent dir missing -> reads as offline
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
+        self.app.selection_sets = {"set1": {"files": [present, offline], "folders": []}}
+        self.app._active_set_preset = "A"
+
+        self.app.write_back_active_set(
+            snapshot={"files": [present], "folders": []}, authoritative=True
+        )
+
+        self.assertEqual(
+            self.app.selection_sets["set1"], {"files": [present], "folders": []}
+        )
+
+    def test_authoritative_write_keeps_supplied_missing_files(self):
+        present = self._touch("keep.png")
+        offline = "/mnt/usb/later.png"
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
+        self.app.selection_sets = {"set1": {"files": [present], "folders": []}}
+        self.app._active_set_preset = "A"
+
+        self.app.write_back_active_set(
+            snapshot={"files": [present, offline], "folders": []},
+            authoritative=True,
+        )
+
+        self.assertEqual(
+            self.app.selection_sets["set1"],
+            {"files": [present, offline], "folders": []},
+        )
+
+    def test_authoritative_write_forks_shared_set(self):
+        present = self._touch("keep.png")
+        self.app.presets = {
+            "A": {"schedule": {}, "selection_id": "set1"},
+            "B": {"schedule": {}, "selection_id": "set1"},
+        }
+        self.app.selection_sets = {"set1": {"files": ["/x.png"], "folders": []}}
+        self.app._active_set_preset = "B"
+
+        self.app.write_back_active_set(
+            snapshot={"files": [present], "folders": []}, authoritative=True
+        )
+
+        # A keeps the shared set; B forks its own.
+        self.assertEqual(self.app.presets["A"]["selection_id"], "set1")
+        new_id = self.app.presets["B"]["selection_id"]
+        self.assertNotEqual(new_id, "set1")
+        self.assertEqual(
+            self.app.selection_sets[new_id], {"files": [present], "folders": []}
+        )
+        self.assertEqual(
+            self.app.selection_sets["set1"], {"files": ["/x.png"], "folders": []}
+        )
+
+    # -- Manage Order viewer integration ---------------------------------------
+
+    def _prime_viewer_app(self, set_files):
+        """Set up an active preset + live selection for viewer tests."""
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "set1"}}
+        self.app.selection_sets = {"set1": {"files": list(set_files), "folders": []}}
+        self.app._active_set_preset = "A"
+        loadable = self.app.check_files(set_files)["valid_files"]
+        self.app.selection = {"files": loadable, "folders": []}
+        self.app.session_schedule = []
+        self.app.grab_schedule = types.MethodType(lambda s: None, self.app)
+        self.app.randomize_selection.isChecked = lambda: False
+
+    def test_viewer_feeds_missing_files_as_rows(self):
+        present = self._touch("keep.png")
+        offline = "/mnt/usb/gone.png"
+        self._prime_viewer_app([present, offline])
+
+        with patch(
+            "gesturesesh.app.selection.run_selection_order_dialog",
+            return_value={"files": [present], "folders": [], "random_preview": False},
+        ) as mock_dialog:
+            self.app.open_selection_order_viewer()
+
+        # The viewer received the loaded file AND the missing one (as a row).
+        _, kwargs = mock_dialog.call_args
+        self.assertEqual(kwargs["files"], [present, offline])
+
+    def test_viewer_removing_missing_file_sticks(self):
+        present = self._touch("keep.png")
+        offline = "/mnt/usb/gone.png"  # offline drive -> merge would resurrect it
+        self._prime_viewer_app([present, offline])
+
+        # User removes the MISSING row and applies.
+        with patch(
+            "gesturesesh.app.selection.run_selection_order_dialog",
+            return_value={"files": [present], "folders": [], "random_preview": False},
+        ):
+            self.app.open_selection_order_viewer()
+
+        self.assertEqual(
+            self.app.selection_sets["set1"], {"files": [present], "folders": []}
+        )
+        self.assertEqual(self.app.selection["files"], [present])
+
+    def test_viewer_keeping_missing_file_preserves_in_set_not_live(self):
+        present = self._touch("keep.png")
+        offline = "/mnt/usb/later.png"
+        self._prime_viewer_app([present, offline])
+
+        # User keeps the MISSING row and applies.
+        with patch(
+            "gesturesesh.app.selection.run_selection_order_dialog",
+            return_value={
+                "files": [present, offline],
+                "folders": [],
+                "random_preview": False,
+            },
+        ):
+            self.app.open_selection_order_viewer()
+
+        # Kept in the preset for when the drive returns...
+        self.assertEqual(
+            self.app.selection_sets["set1"],
+            {"files": [present, offline], "folders": []},
+        )
+        # ...but excluded from the live, loadable-only selection.
+        self.assertEqual(self.app.selection["files"], [present])
+
+    def test_viewer_preserves_stored_order_on_unchanged_apply(self):
+        # Regression: missing entries must keep their stored position so an
+        # unchanged Apply does not reorder the set (Codex P2).
+        present = self._touch("present.png")
+        missing = "/mnt/usb/missing.png"  # stored BEFORE the present file
+        self._prime_viewer_app([missing, present])
+
+        def echo(*a, **k):
+            # Dialog echoes back exactly what it was shown (Apply, no edits).
+            return {
+                "files": list(k["files"]),
+                "folders": list(k["folders"]),
+                "random_preview": False,
+            }
+
+        with patch(
+            "gesturesesh.app.selection.run_selection_order_dialog", side_effect=echo
+        ) as mock_dialog:
+            self.app.open_selection_order_viewer()
+
+        # Missing item is reinserted at its stored position, not appended.
+        self.assertEqual(mock_dialog.call_args.kwargs["files"], [missing, present])
+        # Round trip preserves saved order instead of [present, missing].
+        self.assertEqual(self.app.selection_sets["set1"]["files"], [missing, present])
+
+    def test_viewer_keeps_invalid_existing_file_out_of_live(self):
+        # Regression: an existing but unsupported saved path (e.g. an AppleDouble
+        # sidecar) must not re-enter the live selection (Codex P2).
+        present = self._touch("present.png")
+        sidecar = self._touch("note.txt")  # exists, but unsupported extension
+
+        self._prime_viewer_app([present, sidecar])
+
+        def echo(*a, **k):
+            return {
+                "files": list(k["files"]),
+                "folders": list(k["folders"]),
+                "random_preview": False,
+            }
+
+        with patch(
+            "gesturesesh.app.selection.run_selection_order_dialog", side_effect=echo
+        ):
+            self.app.open_selection_order_viewer()
+
+        # Stored set keeps the user's full curated list...
+        self.assertEqual(
+            self.app.selection_sets["set1"]["files"], [present, sidecar]
+        )
+        # ...but the live selection excludes the unsupported file.
+        self.assertEqual(self.app.selection["files"], [present])
+
     # -- switch handler --------------------------------------------------------
 
     def test_on_preset_switch_writes_old_and_applies_new(self):

--- a/tests/test_selection_sets.py
+++ b/tests/test_selection_sets.py
@@ -511,6 +511,126 @@ class TestSelectionSets(unittest.TestCase):
         self.assertEqual(self.app.selection["files"], ["/keep.png"])
         self.assertEqual(self.app._active_set_preset, "B")
 
+    def test_on_preset_switch_ignores_unsaved_typed_name(self):
+        # Save As: committing a brand-new (unsaved) name must NOT write the
+        # current selection — intended for the new preset — back onto the
+        # previously active preset (Codex P2). on_preset_switch is a no-op for
+        # names that are not saved presets; save() adopts the name instead.
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "setA"}}
+        self.app.selection_sets = {"setA": {"files": ["/a.png"], "folders": []}}
+        self.app._active_set_preset = "A"
+        # Selection diverged from A's set, intended for the new preset.
+        self.app.selection = {"files": ["/new.png"], "folders": []}
+        self.app.preset_loader_box.currentText = lambda: "BrandNew"
+
+        self.app.on_preset_switch()
+
+        # A's set is untouched and it stays active (save() will retarget it).
+        self.assertEqual(
+            self.app.selection_sets["setA"], {"files": ["/a.png"], "folders": []}
+        )
+        self.assertEqual(self.app._active_set_preset, "A")
+
+    # -- deleting the active preset --------------------------------------------
+
+    def test_delete_active_preset_applies_fallback_set(self):
+        # Deleting the active preset must not leave its stale selection live to
+        # be written onto the fallback preset's set (Codex P1). When the
+        # fallback has a set, switch the live selection to it.
+        b1 = self._touch("b1.png")
+        self.app.presets = {
+            "A": {"schedule": {}, "selection_id": "setA"},
+            "B": {"schedule": {}, "selection_id": "setB"},
+        }
+        self.app.selection_sets = {
+            "setA": {"files": ["/old-a.png"], "folders": []},
+            "setB": {"files": [b1], "folders": []},
+        }
+        self.app._active_set_preset = "A"
+        # Live selection still belongs to the about-to-be-deleted preset A.
+        self.app.selection = {"files": ["/old-a.png"], "folders": []}
+        self.app.preset_loader_box.currentText = MagicMock(side_effect=["A", "B"])
+        self.app.preset_loader_box.currentIndex = MagicMock(return_value=0)
+
+        self.app.delete()
+
+        # Falls to B: active follows and B's set is applied to the selection.
+        self.assertEqual(self.app._active_set_preset, "B")
+        self.assertEqual(self.app.selection["files"], [b1])
+        # A boundary write now stores B's own files, not A's stale ones.
+        self.app.write_back_active_set()
+        self.assertEqual(
+            self.app.selection_sets["setB"], {"files": [b1], "folders": []}
+        )
+
+    def test_delete_active_preset_unlinked_fallback_drops_active(self):
+        # Fallback preset has no set: drop the active link so the deleted
+        # preset's stale selection can't be persisted onto it (Codex P1).
+        self.app.presets = {
+            "A": {"schedule": {}, "selection_id": "setA"},
+            "B": {"schedule": {}},  # no linked set
+        }
+        self.app.selection_sets = {"setA": {"files": ["/old-a.png"], "folders": []}}
+        self.app._active_set_preset = "A"
+        self.app.selection = {"files": ["/old-a.png"], "folders": []}
+        self.app.preset_loader_box.currentText = MagicMock(side_effect=["A", "B"])
+        self.app.preset_loader_box.currentIndex = MagicMock(return_value=0)
+
+        self.app.delete()
+
+        self.assertIsNone(self.app._active_set_preset)
+        # The next boundary write is a no-op; B never adopts A's selection.
+        self.app.write_back_active_set()
+        self.assertNotIn("selection_id", self.app.presets["B"])
+        self.assertEqual(self.app.selection_sets, {})
+
+    def test_delete_only_preset_clears_active(self):
+        # Deleting the last preset empties the combo -> no active preset.
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "setA"}}
+        self.app.selection_sets = {"setA": {"files": ["/a.png"], "folders": []}}
+        self.app._active_set_preset = "A"
+        self.app.selection = {"files": ["/a.png"], "folders": []}
+        self.app.preset_loader_box.currentText = MagicMock(side_effect=["A", ""])
+        self.app.preset_loader_box.currentIndex = MagicMock(return_value=0)
+
+        self.app.delete()
+
+        self.assertIsNone(self.app._active_set_preset)
+
+    # -- editable preset switch (committed typed name) -------------------------
+
+    def test_committing_typed_existing_preset_switches_set(self):
+        # Regression: typing an existing preset name and committing it (Enter /
+        # focus-out) must run the switch-in read via the real signal wiring, not
+        # just load the schedule while the set stays on the old preset (Codex
+        # P2). Uses a real editable combo so the production wiring is exercised.
+        b1 = self._touch("b1.png")
+        combo = QtWidgets.QComboBox()
+        combo.setEditable(True)
+        self.app.preset_loader_box = combo
+        # load() is wired here too; stub it so it doesn't touch other widgets.
+        self.app.load = types.MethodType(lambda s: None, self.app)
+        self.app._connect_preset_loader_signals()
+
+        self.app.presets = {
+            "A": {"schedule": {}, "selection_id": "setA"},
+            "B": {"schedule": {}, "selection_id": "setB"},
+        }
+        self.app.selection_sets = {
+            "setA": {"files": ["/old.png"], "folders": []},
+            "setB": {"files": [b1], "folders": []},
+        }
+        self.app._active_set_preset = "A"
+        self.app.selection = {"files": ["/a-live.png"], "folders": []}
+        combo.addItems(["A", "B"])
+
+        # Type "B" into the line edit and commit it.
+        combo.setEditText("B")
+        combo.lineEdit().editingFinished.emit()
+
+        self.assertEqual(self.app._active_set_preset, "B")
+        self.assertEqual(self.app.selection["files"], [b1])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_session_image_loader.py
+++ b/tests/test_session_image_loader.py
@@ -2,13 +2,16 @@ import os
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
+import io
 import sys
+import tempfile
 import types
 import unittest
 from collections import OrderedDict
 from unittest.mock import MagicMock
 
 import numpy as np
+from PIL import Image
 from PyQt5.QtWidgets import QApplication
 
 sys.path.insert(
@@ -101,3 +104,76 @@ class TestSessionImageLoaderMixin(unittest.TestCase):
         assert SessionImageLoaderMixin.normalize_cvimage_dtype(
             fake, float_image
         ).tolist() == [[0, 255]]
+
+
+class TestExifOrientation(unittest.TestCase):
+    """``IMREAD_UNCHANGED`` ignores EXIF orientation, so decode_with_cv2 must
+    re-apply it (regression from the 0.5.x image-loading refactor)."""
+
+    @staticmethod
+    def _decoder_fake():
+        fake = types.SimpleNamespace()
+        fake._apply_exif_orientation = (
+            lambda cvimage, path: SessionImageLoaderMixin._apply_exif_orientation(
+                fake, cvimage, path
+            )
+        )
+        return fake
+
+    @staticmethod
+    def _write_jpeg(path, height, width, orientation):
+        # A distinctive bright patch in the top-left so we can confirm not just
+        # the shape swap but the rotation direction.
+        arr = np.full((height, width, 3), 30, dtype=np.uint8)
+        arr[0 : height // 2, 0 : width // 2] = (255, 0, 0)
+        image = Image.fromarray(arr)
+        exif = image.getexif()
+        exif[0x0112] = orientation
+        image.save(path, format="JPEG", quality=95, exif=exif)
+
+    def test_decode_with_cv2_rotates_per_orientation_tag(self):
+        fake = self._decoder_fake()
+        with tempfile.TemporaryDirectory() as tmp:
+            # Stored pixels are landscape 20x40 (H x W).
+            for orientation, expect_swap in ((1, False), (6, True), (8, True)):
+                path = os.path.join(tmp, f"o{orientation}.jpg")
+                self._write_jpeg(path, height=20, width=40, orientation=orientation)
+                out = SessionImageLoaderMixin.decode_with_cv2(fake, path)
+                self.assertIsNotNone(out)
+                h, w = out.shape[:2]
+                if expect_swap:
+                    self.assertEqual((h, w), (40, 20), f"orientation {orientation}")
+                else:
+                    self.assertEqual((h, w), (20, 40), f"orientation {orientation}")
+
+    def test_orientation_6_and_8_rotate_opposite_directions(self):
+        fake = self._decoder_fake()
+        with tempfile.TemporaryDirectory() as tmp:
+            p6 = os.path.join(tmp, "o6.jpg")
+            p8 = os.path.join(tmp, "o8.jpg")
+            self._write_jpeg(p6, height=20, width=40, orientation=6)
+            self._write_jpeg(p8, height=20, width=40, orientation=8)
+            out6 = SessionImageLoaderMixin.decode_with_cv2(fake, p6)
+            out8 = SessionImageLoaderMixin.decode_with_cv2(fake, p8)
+            # Both become portrait but the red patch lands in opposite corners:
+            # orientation 6 (90 CW) -> top-right; orientation 8 (90 CCW) -> bottom-left.
+            def is_red(px):
+                b, g, r = int(px[0]), int(px[1]), int(px[2])
+                return r > 150 and g < 80 and b < 80
+            self.assertTrue(is_red(out6[2, -2]))   # top-right
+            self.assertTrue(is_red(out8[-3, 1]))   # bottom-left
+
+    def test_apply_exif_orientation_is_a_noop_without_metadata(self):
+        fake = self._decoder_fake()
+        cvimage = np.zeros((4, 6, 3), dtype=np.uint8)
+        # Resource paths (the break image) and missing Pillow metadata are left
+        # untouched rather than raising.
+        self.assertIs(
+            SessionImageLoaderMixin._apply_exif_orientation(
+                fake, cvimage, ":/break/break.png"
+            ),
+            cvimage,
+        )
+        self.assertIsNone(
+            SessionImageLoaderMixin._apply_exif_orientation(fake, None, "missing.jpg")
+        )


### PR DESCRIPTION
## Release v0.5.6

Merges `release/v0.5.6` into `main`. Bundles #40, #41, and #42; bumps the
version to `0.5.6`.

### Fixed
- **EXIF orientation** — photos with an orientation tag (most phone/camera
  images) display upright again. The v0.5.4 image-loading refactor routed every
  format through `cv2.imdecode(..., IMREAD_UNCHANGED)`, which ignores EXIF
  orientation; the tag is now read and re-applied after decoding, preserving the
  alpha channel and bit depth. (#40)
- **Hidden / AppleDouble files** — macOS `._name.ext` sidecars and other
  dotfiles are no longer added to selections. They share a real image's
  extension but hold only metadata, so they were queued and then failed to
  decode mid-session. They're now skipped silently when adding files or scanning
  folders. (#40)

### Added
- **Reveal in file manager** — "Open Folder" in Manage Order (and the session
  window) now reveals *and selects* the highlighted image in your OS file
  browser (Windows `/select`, macOS `open -R`; Linux opens the folder). (#42)
- **Show Missing filter** — a toggle in Manage Order to isolate just the files
  missing from disk, so they're easy to find in a large list. (#42)
- **Per-preset image sets** — presets now remember the image set last used with
  them and restore it on switch. The store is normalized with copy-on-write
  sharing and offline-drive safety (an unplugged drive never prunes a saved
  set). (#41)

### Changed
- **Missing files are reviewable, not just counted** — switching to a preset
  whose saved set has missing/moved files now points you to Manage Order, where
  those files appear as removable **MISSING** rows (full paths) instead of a
  bare count. Removals stick (even for offline-drive files), missing entries
  keep their saved position, and files on a temporarily disconnected drive stay
  saved in the preset and return when the drive is back. (#41, #42)

## Testing
- Full suite green locally: **100 passed, 2 skipped**.
- New/expanded coverage: `tests/test_file_reveal.py`,
  `tests/test_selection_sets.py` (image-set lifecycle, authoritative write,
  viewer integration, plus order-preservation and result-revalidation
  regressions from Codex review), `tests/test_hidden_files.py`,
  `tests/test_session_image_loader.py`.
