### PR TITLE
Address Codex review: keep image set with its preset on delete and typed switch

### DIFF
--- a/src/gesturesesh/app/presets.py
+++ b/src/gesturesesh/app/presets.py
@@ -302,8 +302,26 @@ class MainAppPresetsMixin:
         finally:
             self._loading = False
         if self._active_set_preset == preset_name:
+            # The active preset was deleted and the combo has fallen to an
+            # adjacent entry (already loaded by the index-change -> load
+            # wiring). The live selection still belongs to the deleted preset,
+            # so it must not reach the fallback's set on the next boundary
+            # write.
             current = self.preset_loader_box.currentText()
-            self._active_set_preset = current if current in self.presets else None
+            fallback = current if current in self.presets else None
+            preset = self.presets.get(fallback) if fallback else None
+            set_id = preset.get("selection_id") if isinstance(preset, dict) else None
+            if set_id:
+                # Treat this as a switch-in to the fallback: adopt it and apply
+                # its saved set so the live selection matches it.
+                self._active_set_preset = fallback
+                self.apply_selection_set(set_id)
+            else:
+                # Nothing to switch to: drop the active link so a later boundary
+                # write is a no-op instead of overwriting the fallback's set
+                # with the deleted preset's stale selection. A deliberate switch
+                # re-establishes tracking.
+                self._active_set_preset = None
 
     def load(self):
         preset_name = self.preset_loader_box.currentText()

--- a/src/gesturesesh/app/selection_sets.py
+++ b/src/gesturesesh/app/selection_sets.py
@@ -298,26 +298,31 @@ class MainAppSelectionSetsMixin:
     def on_preset_switch(self, *args) -> None:
         """Deliberate user preset switch: write back the old set, apply the new.
 
-        Wired to ``QComboBox.activated`` so it fires only on real user selection,
-        not on programmatic index changes or text editing.
+        Wired to ``QComboBox.activated`` (dropdown pick) and the editable line
+        edit's ``editingFinished`` (a typed name committed with Enter/focus-out),
+        so it runs on deliberate selection — not on programmatic index changes
+        or mid-typing text edits.
         """
         if getattr(self, "_loading", False):
             return
         new_name = self.preset_loader_box.currentText()
         if new_name == self._active_set_preset:
             return
+        if new_name not in self.presets:
+            # A typed, not-yet-saved name (Save As). This is not a switch:
+            # writing back here would persist the current selection — intended
+            # for the new preset — onto the OLD preset. Leave the active preset
+            # as-is; save() adopts the new name and stores the selection itself.
+            return
 
         # Boundary write for the preset we are leaving (still the live selection).
         self.write_back_active_set()
 
         # Read for the preset we are entering.
-        self._active_set_preset = new_name if new_name in self.presets else None
-        if self._active_set_preset:
-            preset = self.presets.get(new_name)
-            set_id = (
-                preset.get("selection_id") if isinstance(preset, dict) else None
-            )
-            if set_id:
-                self.apply_selection_set(set_id)
-            # No linked set -> leave the current selection; it becomes this
-            # preset's set on the next boundary write.
+        self._active_set_preset = new_name
+        preset = self.presets.get(new_name)
+        set_id = preset.get("selection_id") if isinstance(preset, dict) else None
+        if set_id:
+            self.apply_selection_set(set_id)
+        # No linked set -> leave the current selection; it becomes this preset's
+        # set on the next boundary write.

--- a/src/gesturesesh/main.py
+++ b/src/gesturesesh/main.py
@@ -166,18 +166,33 @@ class MainApp(
         self.add_entry.clicked.connect(self.append_schedule)
         self.save_preset.clicked.connect(self.save)
         self.delete_preset.clicked.connect(self.delete)
-        self.preset_loader_box.currentIndexChanged.connect(self.load)
-        self.preset_loader_box.currentTextChanged.connect(self.load)
-        # Deliberate user preset switches drive selection-set read/write.
-        # `activated` fires only on real user selection, not programmatic
-        # index changes or typing, which keeps set logic off the re-entrant
-        # currentIndexChanged/currentTextChanged path.
-        self.preset_loader_box.activated.connect(self.on_preset_switch)
+        self._connect_preset_loader_signals()
         # Buttons for table
         self.remove_entry.pressed.connect(self.remove_row)
         self.move_entry_up.clicked.connect(self.move_up)
         self.move_entry_down.clicked.connect(self.move_down)
         self.reset_table.clicked.connect(self.remove_rows)
+
+    def _connect_preset_loader_signals(self):
+        """Wire the preset combo's signals.
+
+        Schedule loading follows index/text changes. The selection-set
+        read/write stays on the *deliberate-switch* triggers so it never runs on
+        the re-entrant ``currentIndexChanged``/``currentTextChanged`` path:
+
+        * ``activated`` – the user picks an entry from the dropdown.
+        * the line edit's ``editingFinished`` – the user types an existing preset
+          name and commits it (Enter / focus-out). ``activated`` does not fire
+          for typing, so without this a typed switch would load the new schedule
+          while the image set stayed on the previously active preset (and a
+          following save/start could persist the old images onto it).
+        """
+        self.preset_loader_box.currentIndexChanged.connect(self.load)
+        self.preset_loader_box.currentTextChanged.connect(self.load)
+        self.preset_loader_box.activated.connect(self.on_preset_switch)
+        line_edit = self.preset_loader_box.lineEdit()
+        if line_edit is not None:
+            line_edit.editingFinished.connect(self.on_preset_switch)
 
     def init_shortcuts(self):
         # Ctrl+Enter to start session

--- a/tests/test_selection_sets.py
+++ b/tests/test_selection_sets.py
@@ -511,6 +511,26 @@ class TestSelectionSets(unittest.TestCase):
         self.assertEqual(self.app.selection["files"], ["/keep.png"])
         self.assertEqual(self.app._active_set_preset, "B")
 
+    def test_on_preset_switch_ignores_unsaved_typed_name(self):
+        # Save As: committing a brand-new (unsaved) name must NOT write the
+        # current selection — intended for the new preset — back onto the
+        # previously active preset (Codex P2). on_preset_switch is a no-op for
+        # names that are not saved presets; save() adopts the name instead.
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "setA"}}
+        self.app.selection_sets = {"setA": {"files": ["/a.png"], "folders": []}}
+        self.app._active_set_preset = "A"
+        # Selection diverged from A's set, intended for the new preset.
+        self.app.selection = {"files": ["/new.png"], "folders": []}
+        self.app.preset_loader_box.currentText = lambda: "BrandNew"
+
+        self.app.on_preset_switch()
+
+        # A's set is untouched and it stays active (save() will retarget it).
+        self.assertEqual(
+            self.app.selection_sets["setA"], {"files": ["/a.png"], "folders": []}
+        )
+        self.assertEqual(self.app._active_set_preset, "A")
+
     # -- deleting the active preset --------------------------------------------
 
     def test_delete_active_preset_applies_fallback_set(self):

--- a/tests/test_selection_sets.py
+++ b/tests/test_selection_sets.py
@@ -511,6 +511,106 @@ class TestSelectionSets(unittest.TestCase):
         self.assertEqual(self.app.selection["files"], ["/keep.png"])
         self.assertEqual(self.app._active_set_preset, "B")
 
+    # -- deleting the active preset --------------------------------------------
+
+    def test_delete_active_preset_applies_fallback_set(self):
+        # Deleting the active preset must not leave its stale selection live to
+        # be written onto the fallback preset's set (Codex P1). When the
+        # fallback has a set, switch the live selection to it.
+        b1 = self._touch("b1.png")
+        self.app.presets = {
+            "A": {"schedule": {}, "selection_id": "setA"},
+            "B": {"schedule": {}, "selection_id": "setB"},
+        }
+        self.app.selection_sets = {
+            "setA": {"files": ["/old-a.png"], "folders": []},
+            "setB": {"files": [b1], "folders": []},
+        }
+        self.app._active_set_preset = "A"
+        # Live selection still belongs to the about-to-be-deleted preset A.
+        self.app.selection = {"files": ["/old-a.png"], "folders": []}
+        self.app.preset_loader_box.currentText = MagicMock(side_effect=["A", "B"])
+        self.app.preset_loader_box.currentIndex = MagicMock(return_value=0)
+
+        self.app.delete()
+
+        # Falls to B: active follows and B's set is applied to the selection.
+        self.assertEqual(self.app._active_set_preset, "B")
+        self.assertEqual(self.app.selection["files"], [b1])
+        # A boundary write now stores B's own files, not A's stale ones.
+        self.app.write_back_active_set()
+        self.assertEqual(
+            self.app.selection_sets["setB"], {"files": [b1], "folders": []}
+        )
+
+    def test_delete_active_preset_unlinked_fallback_drops_active(self):
+        # Fallback preset has no set: drop the active link so the deleted
+        # preset's stale selection can't be persisted onto it (Codex P1).
+        self.app.presets = {
+            "A": {"schedule": {}, "selection_id": "setA"},
+            "B": {"schedule": {}},  # no linked set
+        }
+        self.app.selection_sets = {"setA": {"files": ["/old-a.png"], "folders": []}}
+        self.app._active_set_preset = "A"
+        self.app.selection = {"files": ["/old-a.png"], "folders": []}
+        self.app.preset_loader_box.currentText = MagicMock(side_effect=["A", "B"])
+        self.app.preset_loader_box.currentIndex = MagicMock(return_value=0)
+
+        self.app.delete()
+
+        self.assertIsNone(self.app._active_set_preset)
+        # The next boundary write is a no-op; B never adopts A's selection.
+        self.app.write_back_active_set()
+        self.assertNotIn("selection_id", self.app.presets["B"])
+        self.assertEqual(self.app.selection_sets, {})
+
+    def test_delete_only_preset_clears_active(self):
+        # Deleting the last preset empties the combo -> no active preset.
+        self.app.presets = {"A": {"schedule": {}, "selection_id": "setA"}}
+        self.app.selection_sets = {"setA": {"files": ["/a.png"], "folders": []}}
+        self.app._active_set_preset = "A"
+        self.app.selection = {"files": ["/a.png"], "folders": []}
+        self.app.preset_loader_box.currentText = MagicMock(side_effect=["A", ""])
+        self.app.preset_loader_box.currentIndex = MagicMock(return_value=0)
+
+        self.app.delete()
+
+        self.assertIsNone(self.app._active_set_preset)
+
+    # -- editable preset switch (committed typed name) -------------------------
+
+    def test_committing_typed_existing_preset_switches_set(self):
+        # Regression: typing an existing preset name and committing it (Enter /
+        # focus-out) must run the switch-in read via the real signal wiring, not
+        # just load the schedule while the set stays on the old preset (Codex
+        # P2). Uses a real editable combo so the production wiring is exercised.
+        b1 = self._touch("b1.png")
+        combo = QtWidgets.QComboBox()
+        combo.setEditable(True)
+        self.app.preset_loader_box = combo
+        # load() is wired here too; stub it so it doesn't touch other widgets.
+        self.app.load = types.MethodType(lambda s: None, self.app)
+        self.app._connect_preset_loader_signals()
+
+        self.app.presets = {
+            "A": {"schedule": {}, "selection_id": "setA"},
+            "B": {"schedule": {}, "selection_id": "setB"},
+        }
+        self.app.selection_sets = {
+            "setA": {"files": ["/old.png"], "folders": []},
+            "setB": {"files": [b1], "folders": []},
+        }
+        self.app._active_set_preset = "A"
+        self.app.selection = {"files": ["/a-live.png"], "folders": []}
+        combo.addItems(["A", "B"])
+
+        # Type "B" into the line edit and commit it.
+        combo.setEditText("B")
+        combo.lineEdit().editingFinished.emit()
+
+        self.assertEqual(self.app._active_set_preset, "B")
+        self.assertEqual(self.app.selection["files"], [b1])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Two paths left _active_set_preset out of sync with the live selection, so a boundary write (close/start/save) could persist one preset's images onto a different preset's saved set.
- Deleting the active preset: removeItem falls to a neighbor whose schedule load() loads, but the live selection still belonged to the deleted preset. delete() now applies the fallback preset's set when it has one, and otherwise clears _active_set_preset so the write is a no-op until a deliberate switch.
- Editable-combo switch: the combo is editable and currentTextChanged -> load runs on typing, but the set switch only ran on `activated`, which doesn't fire for typed commits. The line edit's editingFinished now routes through on_preset_switch (wiring grouped in _connect_preset_loader_signals); it fires on commit, before the Save click. 
- Adds delete-fallback and editable-switch regression tests.